### PR TITLE
fix: include binary files in git diff parsing

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -163,15 +163,26 @@ fn find_affected_internal(
 
         // Record direct change cause if generating report
         if generate_report {
-          for &line in &asset_file.changed_lines {
+          if asset_file.changed_lines.is_empty() {
             project_causes
               .entry(pkg.clone())
               .or_default()
               .push(AffectCause::DirectChange {
                 file: asset_path.clone(),
                 symbol: None,
-                line,
+                line: 0,
               });
+          } else {
+            for &line in &asset_file.changed_lines {
+              project_causes
+                .entry(pkg.clone())
+                .or_default()
+                .push(AffectCause::DirectChange {
+                  file: asset_path.clone(),
+                  symbol: None,
+                  line,
+                });
+            }
           }
         }
       }

--- a/src/git.rs
+++ b/src/git.rs
@@ -153,6 +153,11 @@ fn parse_diff(diff: &str) -> Result<Vec<ChangedFile>> {
       if changed_lines.is_empty() {
         if is_rename_or_copy {
           changed_lines.push(1);
+        } else if file_diff
+          .lines()
+          .any(|line| line.starts_with("Binary files"))
+        {
+          debug!("Binary file detected: {}", file_path);
         } else {
           debug!("No changed lines found for file: {}", file_path);
           return None;
@@ -322,6 +327,65 @@ rename to src/new/name.ts
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].file_path.to_str().unwrap(), "src/new/name.ts");
     assert_eq!(result[0].changed_lines, vec![1]);
+  }
+
+  #[test]
+  fn test_parse_diff_binary_file() {
+    let diff = r#"diff --git a/apps/e2e/src/__screenshots__/tests/visual.spec.ts/screenshot.png b/apps/e2e/src/__screenshots__/tests/visual.spec.ts/screenshot.png
+index 1234567..abcdefg 100644
+Binary files a/apps/e2e/src/__screenshots__/tests/visual.spec.ts/screenshot.png and b/apps/e2e/src/__screenshots__/tests/visual.spec.ts/screenshot.png differ
+"#;
+
+    let result = parse_diff(diff).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(
+      result[0].file_path.to_str().unwrap(),
+      "apps/e2e/src/__screenshots__/tests/visual.spec.ts/screenshot.png"
+    );
+    assert!(result[0].changed_lines.is_empty());
+  }
+
+  #[test]
+  fn test_parse_diff_new_binary_file() {
+    let diff = r#"diff --git "a/image.png" "b/image.png"
+new file mode 100644
+index 000000000..26b848d67
+Binary files /dev/null and "b/image.png" differ
+"#;
+
+    let result = parse_diff(diff).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].file_path.to_str().unwrap(), "image.png");
+    assert!(result[0].changed_lines.is_empty());
+  }
+
+  #[test]
+  fn test_parse_diff_binary_mixed_with_source() {
+    let diff = r#"diff --git a/apps/e2e/screenshot.png b/apps/e2e/screenshot.png
+index 1234567..abcdefg 100644
+Binary files a/apps/e2e/screenshot.png and b/apps/e2e/screenshot.png differ
+diff --git a/libs/core/src/utils.ts b/libs/core/src/utils.ts
+index 1234567..abcdefg 100644
+--- a/libs/core/src/utils.ts
++++ b/libs/core/src/utils.ts
+@@ -15,0 +16,1 @@ export function findRootNode() {
++  return node.getParent();
+"#;
+
+    let result = parse_diff(diff).unwrap();
+    assert_eq!(result.len(), 2);
+
+    assert_eq!(
+      result[0].file_path.to_str().unwrap(),
+      "apps/e2e/screenshot.png"
+    );
+    assert!(result[0].changed_lines.is_empty());
+
+    assert_eq!(
+      result[1].file_path.to_str().unwrap(),
+      "libs/core/src/utils.ts"
+    );
+    assert_eq!(result[1].changed_lines, vec![16]);
   }
 
   #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,7 +21,8 @@ pub struct Project {
 pub struct ChangedFile {
   /// Path to the file (relative to workspace root)
   pub file_path: PathBuf,
-  /// Line numbers that changed (1-indexed)
+  /// Line numbers that changed (1-indexed).
+  /// Empty for binary files (entire file considered changed).
   pub changed_lines: Vec<usize>,
 }
 


### PR DESCRIPTION
## Summary

- **Fix binary file detection**: Binary file diffs (e.g. `.png`, `.jpg`, `.woff`) were silently dropped by `parse_diff()` because they have no `@@ ... @@` hunk headers. When `changed_lines` was empty, the parser returned `None`, causing domino to miss projects affected only through binary file changes (e.g. screenshot updates in an e2e test project).
- **Fix report generation**: `--report` mode now records a `DirectChange` cause (line 0) for binary files instead of showing affected projects with zero causes.
- **Tighten detection**: Uses `starts_with("Binary files")` on individual lines rather than `contains()` on the whole diff chunk, preventing theoretical false positives from diff content.

Discovered via a `compare-outputs` CI check failure where traf detected 3 affected projects but domino only detected 2 — missing the e2e project which had a binary `.png` screenshot change.

## Key Changes

- `src/git.rs`: Detect `Binary files ... differ` marker and keep the file with empty `changed_lines`
- `src/core.rs`: Handle empty `changed_lines` in report generation for asset files
- `src/types.rs`: Document that `changed_lines` can be empty for binary files

## Test Plan

- [x] 3 new unit tests: modified binary, new binary, mixed binary+source
- [x] All 47 unit tests pass (`cargo test --lib`)
- [x] No clippy warnings (`cargo clippy --lib`)
- [x] Formatting clean (`cargo fmt --check`)
- [x] Reviewed by rust-specialist agent (approved)
- [x] Reviewed by code-simplifier agent (no changes needed)