### PR TITLE
fix: add .nxignore and .gitignore support to project discovery

### DIFF
--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -3,9 +3,44 @@ pub mod rush;
 pub mod turbo;
 pub mod workspaces;
 
-use crate::error::Result;
+use crate::error::{DominoError, Result};
 use crate::types::Project;
+use ignore::overrides::OverrideBuilder;
+use ignore::WalkBuilder;
 use std::path::Path;
+
+const STATIC_EXCLUDES: &[&str] = &["!node_modules/", "!dist/", "!__fixtures__/"];
+
+/// Build a directory walker that respects .gitignore, custom ignore files, and exclusion patterns.
+pub(crate) fn build_walker(
+  cwd: &Path,
+  extra_excludes: &[&str],
+  custom_ignore_files: &[&str],
+) -> Result<ignore::Walk> {
+  let mut overrides = OverrideBuilder::new(cwd);
+  for pattern in STATIC_EXCLUDES.iter().chain(extra_excludes.iter()) {
+    overrides
+      .add(pattern)
+      .map_err(|e| DominoError::Other(format!("Override error: {}", e)))?;
+  }
+  let overrides = overrides
+    .build()
+    .map_err(|e| DominoError::Other(format!("Override build error: {}", e)))?;
+
+  let mut builder = WalkBuilder::new(cwd);
+  builder
+    .hidden(false)
+    .git_ignore(true)
+    .git_global(true)
+    .git_exclude(true)
+    .overrides(overrides);
+
+  for filename in custom_ignore_files {
+    builder.add_custom_ignore_filename(filename);
+  }
+
+  Ok(builder.build())
+}
 
 /// Detect workspace type and discover projects
 pub fn discover_projects(cwd: &Path) -> Result<Vec<Project>> {

--- a/src/workspace/nx.rs
+++ b/src/workspace/nx.rs
@@ -1,6 +1,5 @@
 use crate::error::{DominoError, Result};
 use crate::types::Project;
-use glob::glob;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;
@@ -85,25 +84,25 @@ pub fn get_projects(cwd: &Path) -> Result<Vec<Project>> {
 }
 
 fn get_project_json_projects(cwd: &Path) -> Result<Vec<Project>> {
+  let walker = super::build_walker(cwd, &[], &[".nxignore"])?;
+
   let mut projects = Vec::new();
-
-  let pattern = cwd.join("**/project.json").to_string_lossy().to_string();
-
-  for entry in glob(&pattern).map_err(|e| DominoError::Other(format!("Glob error: {}", e)))? {
-    match entry {
-      Ok(path) => {
-        // Skip node_modules and __fixtures__
-        let path_str = path.to_string_lossy();
-        if path_str.contains("node_modules") || path_str.contains("__fixtures__") {
-          continue;
-        }
-
-        match parse_project_json(&path, cwd) {
-          Ok(project) => projects.push(project),
-          Err(e) => warn!("Failed to parse project.json at {:?}: {}", path, e),
-        }
+  for entry in walker {
+    let entry = match entry {
+      Ok(e) => e,
+      Err(e) => {
+        warn!("Walk error during project discovery: {}", e);
+        continue;
       }
-      Err(e) => warn!("Error reading glob entry: {}", e),
+    };
+    if entry.file_type().is_none_or(|ft| !ft.is_file()) || entry.file_name() != "project.json" {
+      continue;
+    }
+
+    let path = entry.path();
+    match parse_project_json(path, cwd) {
+      Ok(project) => projects.push(project),
+      Err(e) => warn!("Failed to parse project.json at {:?}: {}", path, e),
     }
   }
 
@@ -242,4 +241,157 @@ fn get_workspace_json_projects(cwd: &Path) -> Result<Vec<Project>> {
   }
 
   Ok(projects)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::fs;
+  use std::process::Command;
+  use tempfile::TempDir;
+
+  fn create_nx_fixture() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+
+    Command::new("git")
+      .args(["init", "-q"])
+      .current_dir(root)
+      .output()
+      .unwrap();
+
+    fs::write(root.join("nx.json"), r#"{"npmScope": "myorg"}"#).unwrap();
+
+    dir
+  }
+
+  fn write_project_json(root: &Path, dir_name: &str, project_name: &str) {
+    let dir = root.join(dir_name);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+      dir.join("project.json"),
+      format!(r#"{{ "name": "{}" }}"#, project_name),
+    )
+    .unwrap();
+  }
+
+  #[test]
+  fn test_valid_projects_discovered() {
+    let dir = create_nx_fixture();
+    let root = dir.path();
+
+    write_project_json(root, "libs/shared", "shared");
+    write_project_json(root, "apps/web", "web");
+
+    let projects = get_projects(root).unwrap();
+    let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+
+    assert_eq!(projects.len(), 2);
+    assert!(names.contains(&"shared"));
+    assert!(names.contains(&"web"));
+  }
+
+  #[test]
+  fn test_gitignore_excludes_project() {
+    let dir = create_nx_fixture();
+    let root = dir.path();
+
+    write_project_json(root, "libs/shared", "shared");
+    write_project_json(root, "libs/ignored-lib", "ignored-lib");
+
+    fs::write(root.join(".gitignore"), "libs/ignored-lib\n").unwrap();
+
+    let projects = get_projects(root).unwrap();
+    let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+
+    assert_eq!(projects.len(), 1);
+    assert!(names.contains(&"shared"));
+    assert!(!names.contains(&"ignored-lib"));
+  }
+
+  #[test]
+  fn test_nxignore_excludes_project() {
+    let dir = create_nx_fixture();
+    let root = dir.path();
+
+    write_project_json(root, "libs/shared", "shared");
+    write_project_json(root, "libs/nx-ignored", "nx-ignored");
+
+    fs::write(root.join(".nxignore"), "libs/nx-ignored\n").unwrap();
+
+    let projects = get_projects(root).unwrap();
+    let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+
+    assert_eq!(projects.len(), 1);
+    assert!(names.contains(&"shared"));
+    assert!(!names.contains(&"nx-ignored"));
+  }
+
+  #[test]
+  fn test_dist_excluded_by_default() {
+    let dir = create_nx_fixture();
+    let root = dir.path();
+
+    write_project_json(root, "libs/shared", "shared");
+    write_project_json(root, "dist/libs/shared", "shared-dist");
+
+    let projects = get_projects(root).unwrap();
+    let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+
+    assert_eq!(projects.len(), 1);
+    assert!(names.contains(&"shared"));
+    assert!(!names.contains(&"shared-dist"));
+  }
+
+  #[test]
+  fn test_fixtures_excluded_by_default() {
+    let dir = create_nx_fixture();
+    let root = dir.path();
+
+    write_project_json(root, "libs/shared", "shared");
+    write_project_json(root, "__fixtures__/mock-project", "mock");
+
+    let projects = get_projects(root).unwrap();
+    let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+
+    assert_eq!(projects.len(), 1);
+    assert!(names.contains(&"shared"));
+    assert!(!names.contains(&"mock"));
+  }
+
+  #[test]
+  fn test_node_modules_excluded_by_default() {
+    let dir = create_nx_fixture();
+    let root = dir.path();
+
+    write_project_json(root, "libs/shared", "shared");
+    write_project_json(root, "node_modules/some-dep", "some-dep");
+    write_project_json(root, "libs/shared/node_modules/nested-dep", "nested-dep");
+
+    let projects = get_projects(root).unwrap();
+    let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+
+    assert_eq!(projects.len(), 1);
+    assert!(names.contains(&"shared"));
+  }
+
+  #[test]
+  fn test_nested_gitignore_respected() {
+    let dir = create_nx_fixture();
+    let root = dir.path();
+
+    write_project_json(root, "libs/shared", "shared");
+    write_project_json(root, "libs/generated/auto-gen", "auto-gen");
+
+    let libs_dir = root.join("libs/generated");
+    fs::create_dir_all(&libs_dir).unwrap();
+    fs::write(libs_dir.join(".gitignore"), "auto-gen\n").unwrap();
+
+    let projects = get_projects(root).unwrap();
+    let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+
+    assert_eq!(projects.len(), 1);
+    assert!(names.contains(&"shared"));
+    assert!(!names.contains(&"auto-gen"));
+  }
 }

--- a/src/workspace/workspaces.rs
+++ b/src/workspace/workspaces.rs
@@ -1,10 +1,16 @@
 use crate::error::{DominoError, Result};
 use crate::types::Project;
-use glob::glob;
+use glob::{MatchOptions, Pattern};
 use serde::Deserialize;
 use std::fs;
 use std::path::Path;
 use tracing::{debug, warn};
+
+const GLOB_MATCH_OPTIONS: MatchOptions = MatchOptions {
+  case_sensitive: true,
+  require_literal_separator: true,
+  require_literal_leading_dot: false,
+};
 
 #[derive(Debug, Deserialize)]
 struct PnpmWorkspace {
@@ -41,35 +47,46 @@ fn has_npm_workspaces(cwd: &Path) -> bool {
 pub fn get_projects(cwd: &Path) -> Result<Vec<Project>> {
   let workspace_patterns = get_workspace_patterns(cwd)?;
 
-  let mut projects = Vec::new();
+  let glob_patterns: Vec<Pattern> = workspace_patterns
+    .iter()
+    .filter(|p| !p.starts_with('!'))
+    .filter_map(|p| Pattern::new(&format!("{}/package.json", p)).ok())
+    .collect();
 
-  for pattern in &workspace_patterns {
-    // Skip negated patterns (starting with !)
-    if pattern.starts_with('!') {
+  if glob_patterns.is_empty() {
+    return Ok(vec![]);
+  }
+
+  let walker = super::build_walker(cwd, &[], &[])?;
+
+  let mut projects = Vec::new();
+  for entry in walker {
+    let entry = match entry {
+      Ok(e) => e,
+      Err(e) => {
+        warn!("Walk error during workspace discovery: {}", e);
+        continue;
+      }
+    };
+    if entry.file_type().is_none_or(|ft| !ft.is_file()) || entry.file_name() != "package.json" {
       continue;
     }
 
-    let glob_pattern = cwd.join(pattern).join("package.json");
-    let pattern_str = glob_pattern.to_string_lossy().to_string();
+    let relative = match entry.path().strip_prefix(cwd) {
+      Ok(rel) => rel,
+      Err(_) => continue,
+    };
 
-    for entry in glob(&pattern_str).map_err(|e| DominoError::Other(format!("Glob error: {}", e)))? {
-      match entry {
-        Ok(package_json_path) => {
-          // Skip node_modules
-          if package_json_path.to_string_lossy().contains("node_modules") {
-            continue;
-          }
+    if !glob_patterns
+      .iter()
+      .any(|p| p.matches_path_with(relative, GLOB_MATCH_OPTIONS))
+    {
+      continue;
+    }
 
-          match parse_package_json(&package_json_path, cwd) {
-            Ok(project) => projects.push(project),
-            Err(e) => warn!(
-              "Failed to parse package.json at {:?}: {}",
-              package_json_path, e
-            ),
-          }
-        }
-        Err(e) => warn!("Error reading glob entry: {}", e),
-      }
+    match parse_package_json(entry.path(), cwd) {
+      Ok(project) => projects.push(project),
+      Err(e) => warn!("Failed to parse package.json at {:?}: {}", entry.path(), e),
     }
   }
 
@@ -127,4 +144,186 @@ fn parse_package_json(path: &Path, cwd: &Path) -> Result<Project> {
     implicit_dependencies: vec![],
     targets: vec![],
   })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::fs;
+  use std::process::Command;
+  use tempfile::TempDir;
+
+  fn create_workspace_fixture(patterns: &[&str]) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+
+    Command::new("git")
+      .args(["init", "-q"])
+      .current_dir(root)
+      .output()
+      .unwrap();
+
+    let workspaces_json: Vec<String> = patterns.iter().map(|p| format!(r#""{}""#, p)).collect();
+    fs::write(
+      root.join("package.json"),
+      format!(
+        r#"{{ "name": "root", "workspaces": [{}] }}"#,
+        workspaces_json.join(", ")
+      ),
+    )
+    .unwrap();
+
+    dir
+  }
+
+  fn write_package_json(root: &std::path::Path, dir_name: &str, pkg_name: &str) {
+    let dir = root.join(dir_name);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+      dir.join("package.json"),
+      format!(r#"{{ "name": "{}" }}"#, pkg_name),
+    )
+    .unwrap();
+  }
+
+  #[test]
+  fn test_valid_workspace_projects_discovered() {
+    let dir = create_workspace_fixture(&["packages/*"]);
+    let root = dir.path();
+
+    write_package_json(root, "packages/utils", "@myorg/utils");
+    write_package_json(root, "packages/core", "@myorg/core");
+
+    let projects = get_projects(root).unwrap();
+    let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+
+    assert_eq!(projects.len(), 2);
+    assert!(names.contains(&"@myorg/utils"));
+    assert!(names.contains(&"@myorg/core"));
+  }
+
+  #[test]
+  fn test_gitignore_excludes_workspace_project() {
+    let dir = create_workspace_fixture(&["packages/*"]);
+    let root = dir.path();
+
+    write_package_json(root, "packages/utils", "@myorg/utils");
+    write_package_json(root, "packages/ignored-pkg", "@myorg/ignored-pkg");
+
+    fs::write(root.join(".gitignore"), "packages/ignored-pkg\n").unwrap();
+
+    let projects = get_projects(root).unwrap();
+    let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+
+    assert_eq!(projects.len(), 1);
+    assert!(names.contains(&"@myorg/utils"));
+    assert!(!names.contains(&"@myorg/ignored-pkg"));
+  }
+
+  #[test]
+  fn test_dist_excluded_by_default() {
+    let dir = create_workspace_fixture(&["packages/*", "dist/*"]);
+    let root = dir.path();
+
+    write_package_json(root, "packages/utils", "@myorg/utils");
+    write_package_json(root, "dist/utils", "@myorg/utils-dist");
+
+    let projects = get_projects(root).unwrap();
+    let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+
+    assert_eq!(projects.len(), 1);
+    assert!(names.contains(&"@myorg/utils"));
+    assert!(!names.contains(&"@myorg/utils-dist"));
+  }
+
+  #[test]
+  fn test_pnpm_workspace_discovery() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+
+    Command::new("git")
+      .args(["init", "-q"])
+      .current_dir(root)
+      .output()
+      .unwrap();
+
+    fs::write(
+      root.join("pnpm-workspace.yaml"),
+      "packages:\n  - 'apps/*'\n  - 'libs/*'\n",
+    )
+    .unwrap();
+
+    write_package_json(root, "apps/web", "@myorg/web");
+    write_package_json(root, "libs/shared", "@myorg/shared");
+
+    let projects = get_projects(root).unwrap();
+    let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+
+    assert_eq!(projects.len(), 2);
+    assert!(names.contains(&"@myorg/web"));
+    assert!(names.contains(&"@myorg/shared"));
+  }
+
+  #[test]
+  fn test_non_matching_packages_excluded() {
+    let dir = create_workspace_fixture(&["packages/*"]);
+    let root = dir.path();
+
+    write_package_json(root, "packages/utils", "@myorg/utils");
+    write_package_json(root, "other/stray", "@myorg/stray");
+
+    let projects = get_projects(root).unwrap();
+    let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+
+    assert_eq!(projects.len(), 1);
+    assert!(names.contains(&"@myorg/utils"));
+  }
+
+  #[test]
+  fn test_node_modules_excluded_by_default() {
+    let dir = create_workspace_fixture(&["packages/*"]);
+    let root = dir.path();
+
+    write_package_json(root, "packages/utils", "@myorg/utils");
+    write_package_json(root, "node_modules/some-dep", "@some/dep");
+    write_package_json(
+      root,
+      "packages/utils/node_modules/nested-dep",
+      "@nested/dep",
+    );
+
+    let projects = get_projects(root).unwrap();
+    let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+
+    assert_eq!(projects.len(), 1);
+    assert!(names.contains(&"@myorg/utils"));
+  }
+
+  #[test]
+  fn test_star_does_not_match_across_separators() {
+    let dir = create_workspace_fixture(&["packages/*"]);
+    let root = dir.path();
+
+    write_package_json(root, "packages/utils", "@myorg/utils");
+    write_package_json(root, "packages/utils/nested/deep", "@myorg/deep");
+
+    let projects = get_projects(root).unwrap();
+    let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+
+    assert_eq!(projects.len(), 1);
+    assert!(names.contains(&"@myorg/utils"));
+  }
+
+  #[test]
+  fn test_source_root_with_absolute_cwd() {
+    let dir = create_workspace_fixture(&["packages/*"]);
+    let root = dir.path();
+
+    write_package_json(root, "packages/utils", "@myorg/utils");
+
+    let projects = get_projects(root).unwrap();
+
+    assert_eq!(projects.len(), 1);
+    assert_eq!(projects[0].source_root, root.join("packages/utils"));
+  }
 }


### PR DESCRIPTION
## Summary

- Replace `glob` crate directory walking with `ignore` crate's `WalkBuilder` in Nx and generic workspace project discovery
- Adds native `.gitignore` support (including nested), `.nxignore` support for Nx workspaces, and static exclusion overrides for `node_modules/`, `dist/`, and `__fixtures__/`
- Fixes false-positive project discovery where domino found `project.json`/`package.json` files in directories that traf correctly filters out (1.15% of production comparisons, all `onlyInDomino`)

## Key changes

| File | Change |
|------|--------|
| `src/workspace/mod.rs` | New shared `build_walker` helper with `STATIC_EXCLUDES` (`node_modules/`, `dist/`, `__fixtures__/`) |
| `src/workspace/nx.rs` | Replace `glob::glob("**/project.json")` with `WalkBuilder` + `.nxignore` support |
| `src/workspace/workspaces.rs` | Replace `glob::glob` with `WalkBuilder` + `glob::Pattern::matches_path_with` (correct separator semantics) |

### Why `matches_path_with`?

The default `Pattern::matches_path` allows `*` to match across path separators (`/`), which would cause `packages/*` to incorrectly match `packages/foo/nested/deep/package.json`. Using `matches_path_with` with `require_literal_separator: true` preserves the same matching behavior as the original `glob::glob` function.

## Test plan

- [x] `cargo clippy --all-targets --all-features` -- clean
- [x] `cargo fmt --all` -- clean
- [x] `cargo test --lib` -- 62/62 pass (15 new tests)
- [x] New tests cover: `.gitignore` exclusion, `.nxignore` exclusion, `node_modules/` exclusion, `dist/` exclusion, `__fixtures__/` exclusion, nested `.gitignore`, pnpm workspaces, glob `*` not crossing separators, non-matching paths

Closes #26

Made with [Cursor](https://cursor.com)