### PR TITLE
fix: use workflow_run for PR preview releases to support fork PRs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -293,13 +293,25 @@ jobs:
             # This allows Yarn to re-evaluate optionalDependencies for the current platform
             yarn install
             yarn test
+  save-pr-metadata:
+    name: Save PR metadata
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number and head SHA
+        run: |
+          echo '{"pr_number": "${{ github.event.pull_request.number }}", "head_sha": "${{ github.event.pull_request.head.sha }}"}' > pr-metadata.json
+      - uses: actions/upload-artifact@v5
+        with:
+          name: pr-metadata
+          path: pr-metadata.json
   publish:
     name: Publish
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
-      pull-requests: write
     needs:
       - lint
       - test-macOS-windows-binding
@@ -322,141 +334,7 @@ jobs:
       - name: List packages
         run: ls -R ./npm
         shell: bash
-      - name: Prepare preview release
-        if: github.event_name == 'pull_request'
-        run: |
-          # Pack ALL packages: platform-specific packages + main package
-          # This is similar to pkg.pr.new approach
-          node scripts/publish-preview.js ./npm/darwin-arm64 ./npm/darwin-x64 ./npm/linux-arm64-musl ./npm/linux-x64-gnu ./npm/linux-x64-musl ./npm/win32-x64-msvc .
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-
-      - name: Read manifest
-        if: github.event_name == 'pull_request'
-        id: manifest
-        run: |
-          echo "data=$(cat manifest.json | jq -c)" >> $GITHUB_OUTPUT
-
-      - name: Create GitHub Release
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        env:
-          MANIFEST: ${{ steps.manifest.outputs.data }}
-        with:
-          script: |
-            const manifest = JSON.parse(process.env.MANIFEST);
-
-            console.log(`Creating release: ${manifest.tagName}`);
-
-            const release = await github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: manifest.tagName,
-              name: manifest.releaseName,
-              body: manifest.releaseNotes,
-              draft: false,
-              prerelease: true,
-              target_commitish: manifest.commitSha
-            });
-
-            console.log(`✓ Created release: ${release.data.html_url}`);
-            return release.data.id;
-
-      - name: Upload Release Assets
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        env:
-          MANIFEST: ${{ steps.manifest.outputs.data }}
-        with:
-          script: |
-            const fs = require('fs');
-            const manifest = JSON.parse(process.env.MANIFEST);
-
-            // Get the release
-            const { data: release } = await github.rest.repos.getReleaseByTag({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag: manifest.tagName
-            });
-
-            console.log(`Uploading assets to release ${manifest.tagName}...`);
-
-            // Upload platform packages
-            for (const pkg of manifest.packages) {
-              console.log(`  Uploading ${pkg.tarball}...`);
-
-              await github.rest.repos.uploadReleaseAsset({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                release_id: release.id,
-                name: pkg.tarball,
-                data: await fs.promises.readFile(pkg.path)
-              });
-
-              console.log(`  ✓ Uploaded ${pkg.tarball}`);
-            }
-
-            // Upload main package
-            console.log(`  Uploading ${manifest.mainPackage.tarball}...`);
-
-            await github.rest.repos.uploadReleaseAsset({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: release.id,
-              name: manifest.mainPackage.tarball,
-              data: await fs.promises.readFile(manifest.mainPackage.path)
-            });
-
-            console.log(`  ✓ Uploaded ${manifest.mainPackage.tarball}`);
-            console.log(`\n✓ All assets uploaded successfully`);
-
-      - name: Post or Update PR Comment
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        env:
-          MANIFEST: ${{ steps.manifest.outputs.data }}
-        with:
-          script: |
-            const manifest = JSON.parse(process.env.MANIFEST);
-            const marker = '<!-- domino-preview-release -->';
-
-            console.log(`Managing PR comment for PR #${manifest.prNumber}...`);
-
-            // Find existing comment with our marker
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number
-            });
-
-            const existingComment = comments.find(comment =>
-              comment.body?.includes(marker)
-            );
-
-            if (existingComment) {
-              // Update existing comment
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existingComment.id,
-                body: manifest.commentBody
-              });
-              console.log(`✓ Updated existing comment #${existingComment.id}`);
-            } else {
-              // Create new comment
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: manifest.commentBody
-              });
-              console.log(`✓ Created new comment`);
-            }
-
       - name: Publish to npm
-        if: github.event_name != 'pull_request'
         run: |
           npm config set provenance true
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,184 @@
+name: Preview Release
+
+# Triggered when the CI workflow completes. Runs with base-branch code and
+# write permissions, so it works for fork PRs (which get read-only tokens
+# on the pull_request event).
+'on':
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  preview-release:
+    name: Preview Release
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Download PR metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-metadata
+          path: .
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR metadata
+        id: pr
+        run: |
+          echo "number=$(jq -r .pr_number pr-metadata.json)" >> $GITHUB_OUTPUT
+          echo "head_sha=$(jq -r .head_sha pr-metadata.json)" >> $GITHUB_OUTPUT
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: bindings-*
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate packages
+        run: node scripts/generate-packages.js
+
+      - name: List packages
+        run: ls -R ./npm
+        shell: bash
+
+      - name: Prepare preview release
+        run: |
+          node scripts/publish-preview.js ./npm/darwin-arm64 ./npm/darwin-x64 ./npm/linux-arm64-musl ./npm/linux-x64-gnu ./npm/linux-x64-musl ./npm/win32-x64-msvc .
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          COMMIT_SHA: ${{ steps.pr.outputs.head_sha }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+
+      - name: Read manifest
+        id: manifest
+        run: |
+          echo "data=$(cat manifest.json | jq -c)" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: actions/github-script@v7
+        env:
+          MANIFEST: ${{ steps.manifest.outputs.data }}
+        with:
+          script: |
+            const manifest = JSON.parse(process.env.MANIFEST);
+
+            console.log(`Creating release: ${manifest.tagName}`);
+
+            const release = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: manifest.tagName,
+              name: manifest.releaseName,
+              body: manifest.releaseNotes,
+              draft: false,
+              prerelease: true,
+              target_commitish: manifest.commitSha
+            });
+
+            console.log(`✓ Created release: ${release.data.html_url}`);
+            return release.data.id;
+
+      - name: Upload Release Assets
+        uses: actions/github-script@v7
+        env:
+          MANIFEST: ${{ steps.manifest.outputs.data }}
+        with:
+          script: |
+            const fs = require('fs');
+            const manifest = JSON.parse(process.env.MANIFEST);
+
+            const { data: release } = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: manifest.tagName
+            });
+
+            console.log(`Uploading assets to release ${manifest.tagName}...`);
+
+            for (const pkg of manifest.packages) {
+              console.log(`  Uploading ${pkg.tarball}...`);
+
+              await github.rest.repos.uploadReleaseAsset({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: release.id,
+                name: pkg.tarball,
+                data: await fs.promises.readFile(pkg.path)
+              });
+
+              console.log(`  ✓ Uploaded ${pkg.tarball}`);
+            }
+
+            console.log(`  Uploading ${manifest.mainPackage.tarball}...`);
+
+            await github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id,
+              name: manifest.mainPackage.tarball,
+              data: await fs.promises.readFile(manifest.mainPackage.path)
+            });
+
+            console.log(`  ✓ Uploaded ${manifest.mainPackage.tarball}`);
+            console.log(`\n✓ All assets uploaded successfully`);
+
+      - name: Post or Update PR Comment
+        uses: actions/github-script@v7
+        env:
+          MANIFEST: ${{ steps.manifest.outputs.data }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            const manifest = JSON.parse(process.env.MANIFEST);
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const marker = '<!-- domino-preview-release -->';
+
+            console.log(`Managing PR comment for PR #${prNumber}...`);
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+
+            const existingComment = comments.find(comment =>
+              comment.body?.includes(marker)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: manifest.commentBody
+              });
+              console.log(`✓ Updated existing comment #${existingComment.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: manifest.commentBody
+              });
+              console.log(`✓ Created new comment`);
+            }


### PR DESCRIPTION
## Summary

- Fork PRs get a read-only `GITHUB_TOKEN`, causing the "Create GitHub Release" step in the Publish job to fail
- Split the PR preview-release logic into a separate `workflow_run`-triggered workflow that runs with base-branch code and full write permissions
- This is the [GitHub-recommended pattern](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run) for granting write access to workflows triggered by fork PRs

## Changes

### `CI.yml`
- Added `save-pr-metadata` job that uploads PR number + head SHA as an artifact (needed because `workflow_run.pull_requests` is unreliable for fork PRs)
- Stripped all PR preview logic from the `publish` job — it now only runs on `push` events (npm publish to registry)
- Removed `pull-requests: write` permission from the publish job since it's no longer needed

### `preview-release.yml` (new)
- Triggered by `workflow_run` on CI completion
- Gated on `conclusion == 'success'` and `event == 'pull_request'`
- Downloads build artifacts from the CI run via `run-id` parameter
- Reads PR metadata from artifact to get PR number and commit SHA
- Runs `generate-packages.js` and `publish-preview.js` from the **base branch** (not PR code — this is what makes it safe)
- Creates GitHub Release, uploads assets, and comments on the PR

## Security

- `workflow_run` always executes code from the **default branch**, not the PR branch — a malicious fork cannot modify the workflow
- Build artifacts (`.node` binaries) are produced by CI which runs PR code, but this workflow only **packages and uploads** them — it doesn't execute them

## Test plan

- [ ] Verify push-to-main still triggers npm publish via the `publish` job in CI.yml
- [ ] Open a PR from a fork and verify the Preview Release workflow triggers after CI succeeds
- [ ] Verify the preview release comment appears on the fork PR

Made with [Cursor](https://cursor.com)