### PR TITLE
ci: auto-version from conventional commits and validate PR titles

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -387,10 +387,10 @@ jobs:
           if [ -z "$LAST_TAG" ]; then
             echo "No previous tags found, using all commits"
             SUBJECTS=$(git log --format="%s" --no-merges)
-            BODIES=$(git log --format="%B" --no-merges)
+            BODIES=$(git log --format="%b" --no-merges)
           else
             SUBJECTS=$(git log "${LAST_TAG}..HEAD" --format="%s" --no-merges)
-            BODIES=$(git log "${LAST_TAG}..HEAD" --format="%B" --no-merges)
+            BODIES=$(git log "${LAST_TAG}..HEAD" --format="%b" --no-merges)
           fi
 
           BUMP="patch"


### PR DESCRIPTION
## Summary
- Automate version bumping in the `publish` job using conventional commit message analysis (`feat:` → minor, `fix:` → patch, `!:`/`BREAKING CHANGE` → major)
- Add `verify-pr-title` job that validates PR titles follow conventional commit format, ensuring clean version bumps on squash-merge
- Simplify npm publish step to always publish (removing old conditional git log checks) and push version commit + tag back to main after successful publish

## Key details
- Version is bumped **before** `generate-packages.js` runs (which reads `package.json` version)
- Uses `--no-git-tag-version --ignore-scripts` to skip local npm scripts that require Rust toolchain
- Version commits (e.g. `0.8.0`) are detected and skipped to prevent re-bumping
- `GITHUB_TOKEN` pushes don't trigger workflows, preventing infinite CI loops
- PR title validation uses env var indirection to prevent script injection

## Test plan
- [ ] Open a PR with a non-conventional title (e.g. "update stuff") — verify `verify-pr-title` fails
- [ ] Open a PR with a valid title (e.g. "fix: something") — verify it passes
- [ ] Merge a `feat:` PR to main — verify publish job bumps minor version, publishes, and pushes version commit + tag
- [ ] Merge a `fix:` PR to main — verify patch bump
- [ ] Verify the bot's version commit (e.g. `0.8.0`) does not trigger another CI run


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced pull request title validation using a conventional-commit-like format.
  * Automated semantic versioning with computed version bumps, version commits, git tagging, and tag pushes.
  * Publish flow updated to fetch full repo history, use authenticated registry access, and set provenance.
  * Publishing now skips already-released versions and is gated to run only for non-release bump workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->