### PR TITLE
ci: auto-version from conventional commits

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -345,6 +345,8 @@ jobs:
     name: Publish
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    env:
+      DRY_RUN: true
     permissions:
       contents: write
       id-token: write
@@ -356,7 +358,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
       - name: Setup node
         uses: actions/setup-node@v6
         with:
@@ -382,16 +384,23 @@ jobs:
 
           echo "is_release=false" >> $GITHUB_OUTPUT
 
-          LAST_TAG=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "")
+          LAST_TAG=$(git describe --tags --abbrev=0 --match "v[0-9]*" 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            LAST_TAG=$(git describe --tags --abbrev=0 --match "[0-9]*" 2>/dev/null || echo "")
+          fi
 
           if [ -z "$LAST_TAG" ]; then
             echo "No previous tags found, using all commits"
             SUBJECTS=$(git log --format="%s" --no-merges)
             BODIES=$(git log --format="%b" --no-merges)
           else
+            echo "Last tag: $LAST_TAG"
             SUBJECTS=$(git log "${LAST_TAG}..HEAD" --format="%s" --no-merges)
             BODIES=$(git log "${LAST_TAG}..HEAD" --format="%b" --no-merges)
           fi
+
+          echo "Commits since last tag:"
+          echo "$SUBJECTS"
 
           BUMP="patch"
 
@@ -430,7 +439,12 @@ jobs:
             exit 0
           fi
           npm config set provenance true
-          npm publish --access public
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "[DRY RUN] npm publish --access public --dry-run"
+            npm publish --access public --dry-run
+          else
+            npm publish --access public
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -442,4 +456,11 @@ jobs:
           git add package.json
           git commit -m "${{ steps.bump.outputs.new_version }}"
           git tag "v${{ steps.bump.outputs.new_version }}"
-          git push origin main --tags
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "[DRY RUN] would push: git push --atomic origin main v${{ steps.bump.outputs.new_version }}"
+            echo "[DRY RUN] version commit: ${{ steps.bump.outputs.new_version }}"
+            echo "[DRY RUN] tag: v${{ steps.bump.outputs.new_version }}"
+            git log -1 --oneline
+          else
+            git push --atomic origin main "v${{ steps.bump.outputs.new_version }}"
+          fi


### PR DESCRIPTION
## Summary
- Auto-determine version bump from conventional commit messages in the publish job (`feat:`→minor, `fix:`→patch, `!:`/`BREAKING CHANGE`→major)
- Validate PR titles follow conventional commit format (with `edited` trigger so renames re-check)
- **Currently in dry-run mode** (`DRY_RUN: true`) — flip to `false` after validating logs

## Fixes from v1 attempt
- **Tag detection**: finds both `v0.7.2` and bare `0.7.2` tags (v1 only matched `v*`, found nothing, scanned all history → false `major` bump to 1.0.0)
- **Atomic push**: `git push --atomic` so version commit + tag either both land or neither does (v1 pushed the tag but not the commit due to branch protection)
- **GH_PAT**: uses `secrets.GH_PAT` (with `GITHUB_TOKEN` fallback) so pushes can bypass branch protection
- **Separate subjects/bodies**: `%s` for type-prefix detection, `%b` for `BREAKING CHANGE` footers (prevents false positives from body text)
- **Idempotent publish**: checks `npm view` before publishing to handle retries gracefully
- **Injection prevention**: PR title passed via env var, not shell interpolation

## Setup required
Add a `GH_PAT` repository secret (see PR description comments for instructions)

## Test plan
- [ ] Merge this PR → verify dry-run logs show correct version bump and tag
- [ ] Flip `DRY_RUN` to `false` and merge a `fix:` commit → verify patch bump + publish + tag
- [ ] Merge a `feat:` commit → verify minor bump


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation infrastructure with improved tag detection and conditional publish workflow. Added dry-run capability and refined authentication token handling for the release process. No end-user features changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->