### PR TITLE
fix(ci): prevent side effects in dry-run mode

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -406,7 +406,7 @@ jobs:
 
           if echo "$SUBJECTS" | grep -qE "^[a-z]+(\(.+\))?!:"; then
             BUMP="major"
-          elif echo "$BODIES" | grep -qE "BREAKING CHANGE"; then
+          elif echo "$BODIES" | grep -qE "^BREAKING[ -]CHANGE:"; then
             BUMP="major"
           elif echo "$SUBJECTS" | grep -qE "^feat(\(.+\))?:"; then
             BUMP="minor"
@@ -452,16 +452,16 @@ jobs:
       - name: Push version commit and tag
         if: steps.version.outputs.is_release != 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json Cargo.toml
-          git commit -m "${{ steps.bump.outputs.new_version }}"
-          git tag "v${{ steps.bump.outputs.new_version }}"
           if [ "$DRY_RUN" = "true" ]; then
+            echo "[DRY RUN] would commit: ${{ steps.bump.outputs.new_version }}"
+            echo "[DRY RUN] would tag: v${{ steps.bump.outputs.new_version }}"
             echo "[DRY RUN] would push: git push --atomic origin main v${{ steps.bump.outputs.new_version }}"
-            echo "[DRY RUN] version commit: ${{ steps.bump.outputs.new_version }}"
-            echo "[DRY RUN] tag: v${{ steps.bump.outputs.new_version }}"
-            git log -1 --oneline
+            git diff --stat
           else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add package.json Cargo.toml
+            git commit -m "${{ steps.bump.outputs.new_version }}"
+            git tag "v${{ steps.bump.outputs.new_version }}"
             git push --atomic origin main "v${{ steps.bump.outputs.new_version }}"
           fi


### PR DESCRIPTION
## Summary

- **Dry-run tag leak**: `git commit` and `git tag` ran unconditionally before the dry-run check, causing tags (e.g. `v2.0.0`) to be created and pushed even in dry-run mode. Moved the entire commit/tag/push sequence inside the non-dry-run branch.
- **False major bump**: `grep -qE "BREAKING CHANGE"` matched casual mentions of "BREAKING CHANGE" in PR description text (e.g. the PR #41 body explaining the feature). Tightened to `^BREAKING[ -]CHANGE:` requiring the conventional commit footer format.
- Deleted the erroneous `v2.0.0` tag from the remote.

## Test plan

- [ ] Merge to main and verify the publish job computes the correct version bump (should be `patch`, not `major`)
- [ ] Verify no tags or commits are created in dry-run mode
- [ ] Verify `git diff --stat` is shown in dry-run output for visibility


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated breaking change detection to require stricter pattern matching in commit messages.
  * Improved release workflow execution flow for dry-run and production deployment modes.
  * Enhanced process output clarity with conditional git operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->