### PR TITLE
Add Tribunal AI review config

### DIFF
--- a/.cursor/hooks/state/continual-learning.json
+++ b/.cursor/hooks/state/continual-learning.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
   "lastRunAtMs": 0,
-  "turnsSinceLastRun": 1,
+  "turnsSinceLastRun": 6,
   "lastTranscriptMtimeMs": null,
-  "lastProcessedGenerationId": "ff41b703-52cb-4386-a083-fed1e182e88c",
+  "lastProcessedGenerationId": "803165db-af69-45eb-9ba3-04e97494a9b9",
   "trialStartedAtMs": null
 }

--- a/.tribunal.yml
+++ b/.tribunal.yml
@@ -16,22 +16,20 @@ tribunal:
 
   agents:
     - name: rust-specialist
-      role: 'Rust expert. Focus on memory safety, ownership patterns, lifetime correctness, idiomatic Rust, and proper error handling. Check for unsafe code, unwrap misuse, and clippy-level issues.'
+      agent: .claude/agents/rust-specialist.md
       provider: anthropic
       model: claude-sonnet-4-6
       context: diff_with_refs
 
-    - name: security-reviewer
-      role: 'Security specialist. Focus on vulnerabilities, unsafe blocks, injection risks, and supply chain concerns in dependencies.'
+    - name: security-specialist
+      agent: .claude/agents/security-specialist.md
       provider: anthropic
       model: claude-sonnet-4-6
       context: diff_with_refs
       weight: 2
 
-    - name: devils-advocate
-      role: 'Challenge every assumption. Question necessity of changes, edge cases, potential regressions, and whether the complexity is justified.'
+    - name: performance-specialist
+      agent: .claude/agents/performance-specialist.md
       provider: anthropic
       model: claude-sonnet-4-6
-      context: diff
-# Tribunal AI enabled
-
+      context: diff_with_refs


### PR DESCRIPTION
## Summary
- Add `.tribunal.yml` configuration for AI-powered PR reviews
- Configures 3 review agents: Rust Specialist, Security Reviewer, Devil's Advocate
- Uses majority quorum (2/3 must approve)

## Test plan
- [ ] Verify Tribunal webhook fires on PR open
- [ ] Verify agents post review comments

🤖 Testing Tribunal AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated AI-assisted code review with specialized agents for Rust quality, security, and performance critique.
  * Majority-based quorum requiring multiple agent approvals (minimum two).
  * Interactive conversation mode enabled, including responses to mentions.
  * Reviews automatically triggered on pull request creation and updates; security reviewer prioritized with higher weight.

* **Chores**
  * Updated persisted continual-learning state for internal hook processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->