### PR TITLE
feat: add --ignore-tsconfig-excludes flag for test targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ domino affected --report report.html
 - `--debug`: Enable debug logging
 - `--cwd <PATH>`: Set the current working directory
 - `--lockfile-strategy <STRATEGY>`: Lockfile change detection strategy (default: `direct`)
+- `--ignore-tsconfig-excludes`: Skip tsconfig exclude patterns (e.g., `*.spec.ts`, `*.stories.tsx`). Useful for test targets where test-file imports should also be traced
 
 ### Lockfile Change Detection
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1027,6 +1027,10 @@
                   <code>direct</code></span
                 >
               </li>
+              <li class="option-item">
+                <span class="option-flag">--ignore-tsconfig-excludes</span>
+                <span class="option-desc">Skip tsconfig exclude patterns (e.g., <code>*.spec.ts</code>, <code>*.stories.tsx</code>). Useful for test targets where test-file imports should also be traced</span>
+              </li>
             </ul>
 
             <h3>Examples</h3>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,11 @@ enum Commands {
     /// Lockfile change detection strategy: none, direct, full
     #[arg(long, default_value = "direct")]
     lockfile_strategy: LockfileStrategy,
+
+    /// Skip tsconfig exclude patterns (e.g., *.spec.ts, *.stories.tsx).
+    /// Useful for test targets where test-file imports should also be traced.
+    #[arg(long)]
+    ignore_tsconfig_excludes: bool,
   },
 }
 
@@ -98,6 +103,7 @@ pub fn run() -> Result<()> {
       profile,
       report,
       lockfile_strategy,
+      ignore_tsconfig_excludes,
     } => {
       let cwd = cwd.unwrap_or_else(|| std::env::current_dir().unwrap());
 
@@ -162,6 +168,7 @@ pub fn run() -> Result<()> {
           ".git".to_string(),
         ],
         lockfile_strategy,
+        ignore_tsconfig_excludes,
       };
 
       // Use the report-generating version if --report is specified

--- a/src/core.rs
+++ b/src/core.rs
@@ -61,7 +61,11 @@ fn find_affected_internal(
   // Step 2: Build project index for O(unique_roots) lookups instead of O(n_projects)
   // Also parses each project's tsconfig to extract exclude patterns, so that
   // files excluded by tsconfig (e.g. stories, specs) don't mark a project affected.
-  let project_index = ProjectIndex::new(&config.projects, &config.cwd);
+  let project_index = ProjectIndex::new(
+    &config.projects,
+    &config.cwd,
+    config.ignore_tsconfig_excludes,
+  );
 
   // Step 3: Build workspace analyzer (includes building import index)
   debug!("Building workspace semantic analysis...");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,8 @@ mod napi_bindings {
     pub enable_profiling: Option<bool>,
     /// Lockfile change detection strategy: "none", "direct", "full" (default: "direct")
     pub lockfile_strategy: Option<String>,
+    /// Skip tsconfig exclude patterns (e.g., *.spec.ts, *.stories.tsx)
+    pub ignore_tsconfig_excludes: Option<bool>,
   }
 
   #[napi(object)]
@@ -100,6 +102,7 @@ mod napi_bindings {
       include: options.include.unwrap_or_default(),
       ignored_paths: options.ignored_paths.unwrap_or_default(),
       lockfile_strategy,
+      ignore_tsconfig_excludes: options.ignore_tsconfig_excludes.unwrap_or(false),
     };
 
     let result =

--- a/src/types.rs
+++ b/src/types.rs
@@ -146,6 +146,9 @@ pub struct TrueAffectedConfig {
   pub ignored_paths: Vec<String>,
   /// Lockfile change detection strategy
   pub lockfile_strategy: LockfileStrategy,
+  /// When true, skip tsconfig exclude patterns (e.g., *.spec.ts, *.stories.tsx).
+  /// Useful for test targets where test-file imports should also be traced.
+  pub ignore_tsconfig_excludes: bool,
 }
 
 /// Result of the true affected analysis

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,7 +33,12 @@ pub struct ProjectIndex {
 impl ProjectIndex {
   /// Build the index from a slice of projects, parsing each project's tsconfig
   /// to extract exclude patterns.
-  pub fn new(projects: &[Project], cwd: &Path) -> Self {
+  ///
+  /// When `ignore_tsconfig_excludes` is true, tsconfig exclude patterns are not
+  /// loaded — every file under a project's sourceRoot counts toward marking it
+  /// affected. This is useful for test targets where test-file imports should
+  /// also be traced.
+  pub fn new(projects: &[Project], cwd: &Path, ignore_tsconfig_excludes: bool) -> Self {
     let mut map: Vec<(PathBuf, Vec<String>)> = Vec::new();
     let mut excludes = FxHashMap::default();
 
@@ -47,17 +52,23 @@ impl ProjectIndex {
         map.push((project.source_root.clone(), vec![project.name.clone()]));
       }
 
-      if let Some(ts_config) = &project.ts_config {
-        if let Some(parsed) = TsconfigExcludes::parse(ts_config, cwd) {
-          debug!(
-            "Loaded {} exclude patterns for project '{}' from {}",
-            parsed.pattern_count(),
-            project.name,
-            ts_config.display()
-          );
-          excludes.insert(project.name.clone(), parsed);
+      if !ignore_tsconfig_excludes {
+        if let Some(ts_config) = &project.ts_config {
+          if let Some(parsed) = TsconfigExcludes::parse(ts_config, cwd) {
+            debug!(
+              "Loaded {} exclude patterns for project '{}' from {}",
+              parsed.pattern_count(),
+              project.name,
+              ts_config.display()
+            );
+            excludes.insert(project.name.clone(), parsed);
+          }
         }
       }
+    }
+
+    if ignore_tsconfig_excludes {
+      debug!("Tsconfig excludes disabled — all files count toward affected detection");
     }
 
     Self {
@@ -190,7 +201,7 @@ mod tests {
       },
     ];
 
-    let index = ProjectIndex::new(&projects, tmp.path());
+    let index = ProjectIndex::new(&projects, tmp.path(), false);
 
     assert_eq!(
       index.get_package_names_by_path(Path::new("libs/core/src/index.ts")),
@@ -233,7 +244,7 @@ mod tests {
       },
     ];
 
-    let index = ProjectIndex::new(&projects, tmp.path());
+    let index = ProjectIndex::new(&projects, tmp.path(), false);
 
     // File in shared sourceRoot should match both projects
     let mut result = index.get_package_names_by_path(Path::new("projects/app-desktop/src/main.ts"));
@@ -270,7 +281,7 @@ mod tests {
       targets: vec![],
     }];
 
-    let index = ProjectIndex::new(&projects, cwd);
+    let index = ProjectIndex::new(&projects, cwd, false);
 
     assert_eq!(
       index.get_package_names_by_path(Path::new("libs/ui-widgets/src/index.ts")),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -163,6 +163,7 @@ impl TestBranch {
       include: vec![],
       ignored_paths: vec![],
       lockfile_strategy: LockfileStrategy::None,
+      ignore_tsconfig_excludes: false,
     };
 
     // Create a profiler (disabled for tests)
@@ -369,6 +370,7 @@ export function anotherFn() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
+      ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -1782,6 +1784,7 @@ export function main() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
+      ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -1889,6 +1892,7 @@ export function main() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
+      ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2015,6 +2019,7 @@ export function main() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
+      ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2145,6 +2150,7 @@ export function run() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
+      ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2235,6 +2241,7 @@ fn test_shared_source_root_all_projects_affected() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
+      ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2412,6 +2419,7 @@ fn test_lockfile_direct_strategy_detects_importing_project() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::Direct,
+      ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2467,6 +2475,7 @@ fn test_lockfile_full_strategy_traces_reference_chain() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::Full,
+      ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2527,6 +2536,7 @@ fn test_lockfile_none_strategy_ignores_lockfile_changes() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
+      ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2578,6 +2588,7 @@ fn test_lockfile_transitive_dep_change_resolves_to_direct() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::Direct,
+      ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2618,6 +2629,7 @@ fn test_lockfile_no_change_zero_impact() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::Direct,
+      ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2763,6 +2775,7 @@ export const mockData: SharedType = { name: 'test' };
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
+      ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2886,6 +2899,7 @@ export const mockData: SharedType = { name: 'test' };
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
+      ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2955,6 +2969,303 @@ fn test_large_single_export_deduplication() {
   assert!(
     affected.contains(&"proj3".to_string()),
     "proj3 should be affected (implicit dep on proj1). Got: {:?}",
+    affected
+  );
+}
+
+// ============================================================================
+// Named Inputs (Nx namedInputs) tests
+// ============================================================================
+
+/// Helper to create a temporary Nx monorepo with namedInputs support
+struct TempNxRepo {
+  dir: TempDir,
+}
+
+impl TempNxRepo {
+  fn new(nx_json: &str) -> Self {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+
+    // Init git
+    git_in(root, &["init", "-q"]);
+    git_in(root, &["config", "user.email", "test@example.com"]);
+    git_in(root, &["config", "user.name", "Test"]);
+    git_in(root, &["branch", "-M", "main"]);
+
+    // Write nx.json
+    fs::write(root.join("nx.json"), nx_json).unwrap();
+
+    // Create two projects
+    fs::create_dir_all(root.join("libs/lib-a/src")).unwrap();
+    fs::write(
+      root.join("libs/lib-a/project.json"),
+      r#"{ "name": "lib-a", "sourceRoot": "libs/lib-a/src" }"#,
+    )
+    .unwrap();
+    fs::write(
+      root.join("libs/lib-a/src/index.ts"),
+      "export const a = 1;\n",
+    )
+    .unwrap();
+
+    fs::create_dir_all(root.join("libs/lib-b/src")).unwrap();
+    fs::write(
+      root.join("libs/lib-b/project.json"),
+      r#"{ "name": "lib-b" }"#,
+    )
+    .unwrap();
+    fs::write(
+      root.join("libs/lib-b/src/index.ts"),
+      "export const b = 2;\n",
+    )
+    .unwrap();
+
+    // Create a workspace-root config file that might be a global input
+    fs::write(root.join("babel.config.json"), "{}").unwrap();
+
+    // Initial commit
+    git_in(root, &["add", "."]);
+    git_in(root, &["commit", "-q", "-m", "init"]);
+
+    // Create test branch
+    git_in(root, &["checkout", "-q", "-b", "test-branch"]);
+
+    Self { dir }
+  }
+
+  fn root(&self) -> &std::path::Path {
+    self.dir.path()
+  }
+
+  fn change_and_commit(&self, file: &str, content: &str) {
+    let path = self.root().join(file);
+    if let Some(parent) = path.parent() {
+      fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(&path, content).unwrap();
+    git_in(self.root(), &["add", file]);
+    git_in(
+      self.root(),
+      &["commit", "-q", "-m", &format!("change {}", file)],
+    );
+  }
+
+  fn get_affected(&self) -> Vec<String> {
+    let projects = domino::workspace::discover_projects(self.root()).unwrap();
+    let config = TrueAffectedConfig {
+      cwd: self.root().to_path_buf(),
+      base: "main".to_string(),
+      root_ts_config: None,
+      projects,
+      include: vec![],
+      ignored_paths: vec![],
+      lockfile_strategy: LockfileStrategy::None,
+      ignore_tsconfig_excludes: false,
+    };
+
+    let profiler = Arc::new(Profiler::new(false));
+    find_affected(config, profiler)
+      .expect("find_affected failed")
+      .affected_projects
+  }
+}
+
+#[test]
+fn test_named_inputs_global_invalidation() {
+  let repo = TempNxRepo::new(
+    r#"{
+      "namedInputs": {
+        "default": ["{projectRoot}/**/*", "sharedGlobals"],
+        "sharedGlobals": ["{workspaceRoot}/babel.config.json"]
+      }
+    }"#,
+  );
+
+  // Change babel.config.json (a global input)
+  repo.change_and_commit("babel.config.json", r#"{"presets": ["@babel/preset-env"]}"#);
+
+  let affected = repo.get_affected();
+
+  // ALL projects should be affected
+  assert!(
+    affected.contains(&"lib-a".to_string()),
+    "lib-a should be affected by global invalidation. Got: {:?}",
+    affected
+  );
+  assert!(
+    affected.contains(&"lib-b".to_string()),
+    "lib-b should be affected by global invalidation. Got: {:?}",
+    affected
+  );
+}
+
+#[test]
+fn test_named_inputs_negation_pattern() {
+  let repo = TempNxRepo::new(
+    r#"{
+      "namedInputs": {
+        "default": [
+          "{projectRoot}/**/*",
+          "!{projectRoot}/**/*.figma.tsx"
+        ]
+      }
+    }"#,
+  );
+
+  // Change a .figma.tsx file (should be negated)
+  repo.change_and_commit(
+    "libs/lib-a/src/Button.figma.tsx",
+    "export const FigmaButton = () => {};\n",
+  );
+
+  let affected = repo.get_affected();
+
+  // lib-a should NOT be affected (the only changed file matches a negation pattern)
+  assert!(
+    !affected.contains(&"lib-a".to_string()),
+    "lib-a should NOT be affected (only .figma.tsx changed, which is negated). Got: {:?}",
+    affected
+  );
+}
+
+#[test]
+fn test_named_inputs_negation_does_not_affect_normal_files() {
+  let repo = TempNxRepo::new(
+    r#"{
+      "namedInputs": {
+        "default": [
+          "{projectRoot}/**/*",
+          "!{projectRoot}/**/*.figma.tsx"
+        ]
+      }
+    }"#,
+  );
+
+  // Change a normal .ts file (should NOT be negated)
+  repo.change_and_commit("libs/lib-a/src/index.ts", "export const a = 42;\n");
+
+  let affected = repo.get_affected();
+
+  // lib-a SHOULD be affected (normal .ts file changed)
+  assert!(
+    affected.contains(&"lib-a".to_string()),
+    "lib-a should be affected (normal .ts file changed). Got: {:?}",
+    affected
+  );
+}
+
+#[test]
+fn test_named_inputs_recursive_resolution() {
+  let repo = TempNxRepo::new(
+    r#"{
+      "namedInputs": {
+        "default": ["{projectRoot}/**/*", "sharedGlobals"],
+        "sharedGlobals": ["{workspaceRoot}/babel.config.json", "ciInputs"],
+        "ciInputs": ["{workspaceRoot}/ci/utils.sh"]
+      }
+    }"#,
+  );
+
+  // Create and change a deeply-nested global input
+  repo.change_and_commit("ci/utils.sh", "#!/bin/bash\necho 'updated'\n");
+
+  let affected = repo.get_affected();
+
+  // ALL projects should be affected (ci/utils.sh is resolved through the chain)
+  assert!(
+    affected.contains(&"lib-a".to_string()),
+    "lib-a should be affected by recursive global invalidation. Got: {:?}",
+    affected
+  );
+  assert!(
+    affected.contains(&"lib-b".to_string()),
+    "lib-b should be affected by recursive global invalidation. Got: {:?}",
+    affected
+  );
+}
+
+#[test]
+fn test_named_inputs_no_config_fallback() {
+  // nx.json without namedInputs — should behave as before
+  let repo = TempNxRepo::new(r#"{"npmScope": "myorg"}"#);
+
+  // Change a normal file
+  repo.change_and_commit("libs/lib-a/src/index.ts", "export const a = 99;\n");
+
+  let affected = repo.get_affected();
+
+  // Only lib-a should be affected (normal behavior)
+  assert!(
+    affected.contains(&"lib-a".to_string()),
+    "lib-a should be affected. Got: {:?}",
+    affected
+  );
+  assert!(
+    !affected.contains(&"lib-b".to_string()),
+    "lib-b should NOT be affected (no cross-file reference). Got: {:?}",
+    affected
+  );
+}
+
+#[test]
+fn test_named_inputs_glob_wildcard_pattern() {
+  let repo = TempNxRepo::new(
+    r#"{
+      "namedInputs": {
+        "default": ["{projectRoot}/**/*", "sharedGlobals"],
+        "sharedGlobals": ["{workspaceRoot}/patches/*"]
+      }
+    }"#,
+  );
+
+  // Create a patch file
+  repo.change_and_commit("patches/some-dep.patch", "--- a/file\n+++ b/file\n");
+
+  let affected = repo.get_affected();
+
+  // ALL projects should be affected
+  assert!(
+    affected.contains(&"lib-a".to_string()),
+    "lib-a should be affected by patches/* glob. Got: {:?}",
+    affected
+  );
+  assert!(
+    affected.contains(&"lib-b".to_string()),
+    "lib-b should be affected by patches/* glob. Got: {:?}",
+    affected
+  );
+}
+
+#[test]
+fn test_named_inputs_negation_with_root_differs_from_source_root() {
+  // lib-a has sourceRoot = "libs/lib-a/src" but project root = "libs/lib-a"
+  // Negation patterns should match against project root, not sourceRoot
+  let repo = TempNxRepo::new(
+    r#"{
+      "namedInputs": {
+        "default": [
+          "{projectRoot}/**/*",
+          "!{projectRoot}/**/*.figma.tsx"
+        ]
+      }
+    }"#,
+  );
+
+  // Change a .figma.tsx file INSIDE sourceRoot — the negation pattern
+  // ({projectRoot}/**/*.figma.tsx) should still exclude it since it's matched
+  // relative to project root (libs/lib-a), not sourceRoot (libs/lib-a/src).
+  repo.change_and_commit(
+    "libs/lib-a/src/Button.figma.tsx",
+    "export const FigmaButton = () => {};\n",
+  );
+
+  let affected = repo.get_affected();
+
+  // lib-a should NOT be affected — negation pattern excludes .figma.tsx files
+  assert!(
+    !affected.contains(&"lib-a".to_string()),
+    "lib-a should NOT be affected (.figma.tsx matched by negation pattern against project root). Got: {:?}",
     affected
   );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -370,7 +370,7 @@ export function anotherFn() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
-      ignore_tsconfig_excludes: false,
+    ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -1784,7 +1784,7 @@ export function main() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
-      ignore_tsconfig_excludes: false,
+    ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -1892,7 +1892,7 @@ export function main() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
-      ignore_tsconfig_excludes: false,
+    ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2019,7 +2019,7 @@ export function main() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
-      ignore_tsconfig_excludes: false,
+    ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2150,7 +2150,7 @@ export function run() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
-      ignore_tsconfig_excludes: false,
+    ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2241,7 +2241,7 @@ fn test_shared_source_root_all_projects_affected() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
-      ignore_tsconfig_excludes: false,
+    ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2419,7 +2419,7 @@ fn test_lockfile_direct_strategy_detects_importing_project() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::Direct,
-      ignore_tsconfig_excludes: false,
+    ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2475,7 +2475,7 @@ fn test_lockfile_full_strategy_traces_reference_chain() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::Full,
-      ignore_tsconfig_excludes: false,
+    ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2536,7 +2536,7 @@ fn test_lockfile_none_strategy_ignores_lockfile_changes() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
-      ignore_tsconfig_excludes: false,
+    ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2588,7 +2588,7 @@ fn test_lockfile_transitive_dep_change_resolves_to_direct() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::Direct,
-      ignore_tsconfig_excludes: false,
+    ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2629,7 +2629,7 @@ fn test_lockfile_no_change_zero_impact() {
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::Direct,
-      ignore_tsconfig_excludes: false,
+    ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2775,7 +2775,7 @@ export const mockData: SharedType = { name: 'test' };
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
-      ignore_tsconfig_excludes: false,
+    ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));
@@ -2899,7 +2899,7 @@ export const mockData: SharedType = { name: 'test' };
     include: vec![],
     ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
-      ignore_tsconfig_excludes: false,
+    ignore_tsconfig_excludes: false,
   };
 
   let profiler = Arc::new(Profiler::new(false));


### PR DESCRIPTION
## Summary
- Adds `--ignore-tsconfig-excludes` CLI flag and `ignoreTsconfigExcludes` N-API option
- When set, domino skips tsconfig exclude patterns (e.g., `*.spec.ts`, `*.stories.tsx`) during affected detection
- All files under a project's sourceRoot count toward marking it affected, including test files

## Motivation

Domino uses `tsconfig.lib.json` exclude patterns to skip test/story files when determining affected projects. This is correct for **build** targets — you don't want to rebuild a library just because a test file changed.

However, for **test** targets, this causes false negatives: if a project's only dependency on a changed library is through test files (e.g., `.spec.ts` importing `ApplicationIds` from a shared lib), domino misses the project entirely.

Real example: [zeroabstraction/apps#28357](https://github.com/zeroabstraction/apps/pull/28357) — domino found 10 affected projects, Nx found 1050. The `island-feature-policy-common:test` target was missed because it only imports from `policy-application-parameters` in test files.

## Usage

```bash
# For build/lint/typecheck targets (default — excludes test files)
domino affected --json

# For test targets (includes test file imports)
domino affected --json --ignore-tsconfig-excludes
```

## Test plan
- [x] All 169 lib unit tests pass
- [x] Clean release build, no warnings
- [x] No behavior change when flag is not provided (default `false`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI flag to optionally bypass tsconfig exclude patterns during affected-file analysis
  * Exposed corresponding option in the public API to control tsconfig exclude handling

* **Tests**
  * Added comprehensive test suite validating Nx namedInputs behavior (workspace/global invalidation, negation, recursion, glob semantics)

* **Documentation**
  * Updated README and docs to document the new CLI flag and its effect on tracing test files
<!-- end of auto-generated comment: release notes by coderabbit.ai -->