### PR TITLE
fix(git): expand changed_lines to full hunk range

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -9,7 +9,7 @@ use tracing::{debug, warn};
 static FILE_RE: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r#"(?:["\s]a/)(.*)(?:["\s]b/)"#).expect("file regex is valid"));
 static LINE_RE: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new(r"@@ -.* \+(\d+)(?:,\d+)? @@").expect("line regex is valid"));
+  LazyLock::new(|| Regex::new(r"@@ -.* \+(\d+)(?:,(\d+))? @@").expect("line regex is valid"));
 
 /// Detect the default branch (tries origin/main, then origin/master)
 pub fn detect_default_branch(repo_path: &Path) -> String {
@@ -187,11 +187,22 @@ fn parse_diff(diff: &str) -> Result<Vec<ChangedFile>> {
       let is_rename_or_copy = new_path.is_some();
       let file_path = new_path.unwrap_or(file_path);
 
-      // Extract changed line numbers
+      // Extract changed line numbers. For each hunk header `@@ -X,Y +Z,W @@`
+      // expand to every line in the new-side range `Z..Z+W`, so symbols that
+      // live mid-hunk (not just at the hunk's starting line) are visible to
+      // downstream AST lookups. When `,W` is omitted, git's convention is a
+      // single-line hunk (count = 1).
       let mut changed_lines: Vec<usize> = line_regex
         .captures_iter(file_diff)
-        .filter_map(|caps| caps.get(1))
-        .filter_map(|m| m.as_str().parse::<usize>().ok())
+        .filter_map(|caps| {
+          let start: usize = caps.get(1)?.as_str().parse().ok()?;
+          let count: usize = caps
+            .get(2)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(1);
+          Some(start..start + count)
+        })
+        .flatten()
         .collect();
 
       if changed_lines.is_empty() {
@@ -258,7 +269,7 @@ index 9876543..fedcba9 100644
     assert_eq!(result[0].changed_lines, vec![16, 46]);
 
     assert_eq!(result[1].file_path.to_str().unwrap(), "libs/nx/src/cli.ts");
-    assert_eq!(result[1].changed_lines, vec![103]);
+    assert_eq!(result[1].changed_lines, vec![103, 104]);
   }
 
   #[test]
@@ -320,8 +331,8 @@ index 1234567..abcdefg 100644
       result[0].file_path.to_str().unwrap(),
       "src/quote-page/helper.ts"
     );
-    // Should have both hunks' line numbers
-    assert_eq!(result[0].changed_lines, vec![5, 20]);
+    // Should have every line in each hunk's new-side range
+    assert_eq!(result[0].changed_lines, vec![5, 20, 21, 22]);
   }
 
   #[test]
@@ -444,5 +455,76 @@ copy to src/copied.ts
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].file_path.to_str().unwrap(), "src/copied.ts");
     assert_eq!(result[0].changed_lines, vec![1]);
+  }
+
+  /// Regression test for https://github.com/frontops-dev/domino/issues/62.
+  /// A multi-line hunk must contribute every line in its new-side range, not
+  /// only the starting line. Otherwise an exported symbol declared mid-hunk
+  /// is invisible to `find_node_at_line`, reference traversal is skipped,
+  /// and downstream consumers are silently dropped from the affected set.
+  #[test]
+  fn test_parse_diff_multi_line_hunk_covers_full_range() {
+    let diff = r#"diff --git a/packages/package-a/src/foo.ts b/packages/package-a/src/foo.ts
+index 1234567..abcdefg 100644
+--- a/packages/package-a/src/foo.ts
++++ b/packages/package-a/src/foo.ts
+@@ -3 +3,7 @@ import { helper } from './helper.js';
+-export const foo = (x: number): number => helper(x) + 1;
++interface FooOptions {
++  offset: number;
++  multiplier: number;
++}
++
++export const foo = (x: number, options: FooOptions = { offset: 1, multiplier: 3 }): number =>
++  helper(x) * options.multiplier + options.offset;
+"#;
+
+    let result = parse_diff(diff).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].changed_lines, vec![3, 4, 5, 6, 7, 8, 9]);
+  }
+
+  /// When the hunk header omits `,W` (single-line hunk), git emits
+  /// `@@ -N +M @@` rather than `@@ -N +M,1 @@`. The regex's count group is
+  /// optional and must fall back to 1 so these hunks still produce a single
+  /// line number.
+  #[test]
+  fn test_parse_diff_shorthand_count_defaults_to_one() {
+    let diff = r#"diff --git a/src/foo.ts b/src/foo.ts
+index 1234567..abcdefg 100644
+--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -1 +1 @@
+-export const foo = 1;
++export const foo = 2;
+"#;
+
+    let result = parse_diff(diff).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].changed_lines, vec![1]);
+  }
+
+  /// A pure-deletion hunk (`+Z,0`) has no new-side lines to scan and must
+  /// contribute zero entries to `changed_lines`. Pair it with a normal hunk
+  /// so the file-skip branch (which triggers on a fully empty result) is not
+  /// what's actually being tested.
+  #[test]
+  fn test_parse_diff_pure_deletion_hunk_contributes_zero() {
+    let diff = r#"diff --git a/src/foo.ts b/src/foo.ts
+index 1234567..abcdefg 100644
+--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -5,3 +5,0 @@ prefix
+-  deleted one
+-  deleted two
+-  deleted three
+@@ -20,0 +21,2 @@ suffix
++  added one
++  added two
+"#;
+
+    let result = parse_diff(diff).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].changed_lines, vec![21, 22]);
   }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -191,8 +191,10 @@ fn parse_diff(diff: &str) -> Result<Vec<ChangedFile>> {
       // expand to every line in the new-side range `Z..Z+W`, so symbols that
       // live mid-hunk (not just at the hunk's starting line) are visible to
       // downstream AST lookups. When `,W` is omitted, git's convention is a
-      // single-line hunk (count = 1).
-      let mut changed_lines: Vec<usize> = line_regex
+      // single-line hunk (count = 1). Pure deletion hunks (`W == 0`) produce
+      // an empty range — see the `has_hunks` branch below for how those are
+      // preserved.
+      let ranges: Vec<std::ops::Range<usize>> = line_regex
         .captures_iter(file_diff)
         .filter_map(|caps| {
           let start: usize = caps.get(1)?.as_str().parse().ok()?;
@@ -202,12 +204,19 @@ fn parse_diff(diff: &str) -> Result<Vec<ChangedFile>> {
             .unwrap_or(1);
           Some(start..start + count)
         })
-        .flatten()
         .collect();
+      let has_hunks = !ranges.is_empty();
+      let mut changed_lines: Vec<usize> = ranges.into_iter().flatten().collect();
 
       if changed_lines.is_empty() {
         if is_rename_or_copy {
           changed_lines.push(1);
+        } else if has_hunks {
+          // Deletion-only file (every hunk is `+Z,0`). Keep the file entry
+          // with no line numbers so its owning package is still marked as
+          // affected — deleting an exported symbol is a real change even
+          // though there's nothing in the new file to AST-lookup.
+          debug!("Only deletion hunks for file: {}", file_path);
         } else if file_diff
           .lines()
           .any(|line| line.starts_with("Binary files"))
@@ -457,11 +466,11 @@ copy to src/copied.ts
     assert_eq!(result[0].changed_lines, vec![1]);
   }
 
-  /// Regression test for https://github.com/frontops-dev/domino/issues/62.
-  /// A multi-line hunk must contribute every line in its new-side range, not
-  /// only the starting line. Otherwise an exported symbol declared mid-hunk
-  /// is invisible to `find_node_at_line`, reference traversal is skipped,
-  /// and downstream consumers are silently dropped from the affected set.
+  /// Regression test for issue #62. A multi-line hunk must contribute every
+  /// line in its new-side range, not only the starting line. Otherwise an
+  /// exported symbol declared mid-hunk is invisible to `find_node_at_line`,
+  /// reference traversal is skipped, and downstream consumers are silently
+  /// dropped from the affected set.
   #[test]
   fn test_parse_diff_multi_line_hunk_covers_full_range() {
     let diff = r#"diff --git a/packages/package-a/src/foo.ts b/packages/package-a/src/foo.ts
@@ -526,5 +535,29 @@ index 1234567..abcdefg 100644
     let result = parse_diff(diff).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].changed_lines, vec![21, 22]);
+  }
+
+  /// A file whose only hunks are deletions (`+Z,0`) must still be kept in
+  /// the result with an empty `changed_lines`. Dropping it would hide real
+  /// source changes — deleting an exported symbol is a meaningful change
+  /// even though there are no new-file lines to AST-lookup. Downstream in
+  /// `core.rs`, the file's owning package is still marked affected because
+  /// the file path is present.
+  #[test]
+  fn test_parse_diff_deletion_only_file_kept_with_empty_lines() {
+    let diff = r#"diff --git a/src/foo.ts b/src/foo.ts
+index 1234567..abcdefg 100644
+--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -5,3 +5,0 @@ export function foo() {
+-  deleted one
+-  deleted two
+-  deleted three
+"#;
+
+    let result = parse_diff(diff).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].file_path.to_str().unwrap(), "src/foo.ts");
+    assert!(result[0].changed_lines.is_empty());
   }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -197,10 +197,19 @@ fn parse_diff(diff: &str) -> Result<Vec<ChangedFile>> {
       let ranges: Vec<std::ops::Range<usize>> = line_regex
         .captures_iter(file_diff)
         .filter_map(|caps| {
-          let start: usize = caps.get(1)?.as_str().parse().ok()?;
+          let start_str = caps.get(1)?.as_str();
+          let start: usize = start_str
+            .parse()
+            .inspect_err(|e| warn!("Failed to parse hunk start line '{}': {}", start_str, e))
+            .ok()?;
           let count: usize = caps
             .get(2)
-            .and_then(|m| m.as_str().parse().ok())
+            .and_then(|m| {
+              m.as_str()
+                .parse()
+                .inspect_err(|e| warn!("Failed to parse hunk count '{}': {}", m.as_str(), e))
+                .ok()
+            })
             .unwrap_or(1);
           Some(start..start + count)
         })
@@ -559,5 +568,30 @@ index 1234567..abcdefg 100644
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].file_path.to_str().unwrap(), "src/foo.ts");
     assert!(result[0].changed_lines.is_empty());
+  }
+
+  /// Symmetric hunk header — old and new sides both carry a count. Common in
+  /// diffs with non-zero context (`--unified=N` for N > 0) or when an edit
+  /// replaces a block with another block of the same size. The greedy `.*`
+  /// in `LINE_RE` already handles this; the test locks it in against future
+  /// regex tweaks.
+  #[test]
+  fn test_parse_diff_symmetric_hunk_with_old_and_new_counts() {
+    let diff = r#"diff --git a/src/foo.ts b/src/foo.ts
+index 1234567..abcdefg 100644
+--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -3,3 +3,3 @@ import { helper } from './helper.js';
+-old line 3
+-old line 4
+-old line 5
++new line 3
++new line 4
++new line 5
+"#;
+
+    let result = parse_diff(diff).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].changed_lines, vec![3, 4, 5]);
   }
 }


### PR DESCRIPTION
Closes #62.

## Summary

`LINE_RE` in `src/git.rs` captured only the starting line of each diff hunk and dropped the count group (`,W`). With `--unified=0` (which `get_diff` always uses), a multi-line hunk like `@@ -3 +3,7 @@` contributed only line 3 to `changed_lines`, so `find_node_at_line` in `core.rs` only looked at line 3. Any exported symbol declared mid-hunk — on, say, line 8 — was invisible. With no traceable symbol, reference traversal was skipped and downstream consumers were silently dropped from the affected set.

This is direction (1) from the issue: capture the count group, expand each hunk's starting line to the full `start..start + count` range. When `,W` is absent git treats the hunk as a single line, so the count group stays optional and defaults to `1`.

## Change

`src/git.rs`:

```diff
-  LazyLock::new(|| Regex::new(r"@@ -.* \+(\d+)(?:,\d+)? @@").expect("line regex is valid"));
+  LazyLock::new(|| Regex::new(r"@@ -.* \+(\d+)(?:,(\d+))? @@").expect("line regex is valid"));
```

```rust
let mut changed_lines: Vec<usize> = line_regex
  .captures_iter(file_diff)
  .filter_map(|caps| {
    let start: usize = caps.get(1)?.as_str().parse().ok()?;
    let count: usize = caps
      .get(2)
      .and_then(|m| m.as_str().parse().ok())
      .unwrap_or(1);
    Some(start..start + count)
  })
  .flatten()
  .collect();
```

## Tests

Added three new unit tests in `src/git.rs`:

- **`test_parse_diff_multi_line_hunk_covers_full_range`** — mirrors the issue's reproduction. Hunk `@@ -3 +3,7 @@` must produce `[3, 4, 5, 6, 7, 8, 9]`. This is the regression test.
- **`test_parse_diff_shorthand_count_defaults_to_one`** — pins the fallback for hunks emitted without `,W` (e.g. `@@ -1 +1 @@`).
- **`test_parse_diff_pure_deletion_hunk_contributes_zero`** — uses a diff with a pure-deletion hunk (`+Z,0`) paired with a real addition hunk, so the assertion targets the "deletion contributes nothing" behavior rather than the file-skip branch.

Updated two existing tests whose expected output changes because their hunks now contribute every line rather than just the first:

- `test_parse_diff` — the second file's hunk `@@ -102,0 +103,2 @@` now yields `[103, 104]` (was `[103]`).
- `test_parse_diff_renamed_file_with_changes` — hunks `@@ -5,1 +5,1 @@` and `@@ -20,0 +20,3 @@` now yield `[5, 20, 21, 22]` (was `[5, 20]`).

All 13 `git::tests::*` pass (`cargo test --lib`), along with the full 184-test `--lib` suite. `cargo fmt -- --check` passes. `cargo clippy` on `src/git.rs` emits no warnings.

## Caller impact

Reviewed every use of `ChangedFile.changed_lines`:

- `core.rs:147-161` — for each line, looks up a symbol via `find_node_at_line`, then deduplicates via `unique_symbols: FxHashSet<&String>`. Extra lines inside the same exported declaration collapse into one trace; extra lines outside any declaration contribute an empty `Vec<String>` and do nothing. No behavioural change except that the bug is fixed.
- `core.rs:269-289` — one `AffectCause::DirectChange { line }` entry per line for asset causes. The report will now list more cause entries per affected package on multi-line hunks, which is a correctness improvement (previously under-reported).
- `lockfile.rs` — only reads `file_path`; never reads `changed_lines` outside test fixtures.

No changes to `ChangedFile`, no new public API.

## Out of scope

Directions (2) and (3) from the issue (fallback to all exports; old/new AST matching) are deferred as future improvements per the maintainer's triage.

## Manual validation

Against the minimal fixture from the issue (`/tmp/domino-repro`, a two-package Rush workspace where `package-b` imports a symbol from `package-a`'s `foo.ts`):

| Branch | Before | After |
|---|---|---|
| `simple-edit` (1-char body change) | `[package-a, package-b]` | `[package-a, package-b]` |
| `rewrite` (interface inserted before export) | `[package-a]` ❌ | `[package-a, package-b]` ✅ |

Both branches now correctly mark `package-b` as affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Git diff parsing now correctly recognizes optional hunk lengths and records the full inclusive new-side line ranges for multi-line hunks, and preserves files that are deletion-only with an empty changed-line list.

* **Tests**
  * Added and updated regression tests for multi-line hunks, shorthand hunk counts, pure-deletion hunks, and full-range line coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->