### PR TITLE
fix: resolve clippy collapsible_match warnings and pin toolchain

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ env:
   APP_NAME: domino
   MACOSX_DEPLOYMENT_TARGET: '10.13'
   CARGO_INCREMENTAL: '1'
+  RUST_TOOLCHAIN: '1.95'
 'on':
   push:
     branches:
@@ -39,6 +40,7 @@ jobs:
       - name: Install
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: clippy, rustfmt
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -115,7 +117,7 @@ jobs:
       - name: Install
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: ${{ matrix.settings.target }}
       - name: Cache cargo
         uses: actions/cache@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,14 +36,8 @@ jobs:
         with:
           node-version: 24
           cache: yarn
-      - name: Read Rust toolchain version
-        id: rust-toolchain
-        run: echo "channel=$(grep 'channel' rust-toolchain.toml | sed 's/.*= *"\(.*\)"/\1/')" >> $GITHUB_OUTPUT
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
-          components: clippy, rustfmt
+        run: rustup show
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Oxlint
@@ -116,14 +110,10 @@ jobs:
         with:
           node-version: 24
           cache: yarn
-      - name: Read Rust toolchain version
-        id: rust-toolchain
-        run: echo "channel=$(grep 'channel' rust-toolchain.toml | sed 's/.*= *"\(.*\)"/\1/')" >> $GITHUB_OUTPUT
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
-          targets: ${{ matrix.settings.target }}
+        run: |
+          rustup show
+          rustup target add ${{ matrix.settings.target }}
       - name: Cache cargo
         uses: actions/cache@v4
         if: ${{ !contains(matrix.settings.target, 'linux-gnu') }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,6 @@ env:
   APP_NAME: domino
   MACOSX_DEPLOYMENT_TARGET: '10.13'
   CARGO_INCREMENTAL: '1'
-  RUST_TOOLCHAIN: '1.95'
 'on':
   push:
     branches:
@@ -37,10 +36,13 @@ jobs:
         with:
           node-version: 24
           cache: yarn
-      - name: Install
-        uses: dtolnay/rust-toolchain@stable
+      - name: Read Rust toolchain version
+        id: rust-toolchain
+        run: echo "channel=$(grep 'channel' rust-toolchain.toml | sed 's/.*= *"\(.*\)"/\1/')" >> $GITHUB_OUTPUT
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
           components: clippy, rustfmt
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -114,10 +116,13 @@ jobs:
         with:
           node-version: 24
           cache: yarn
-      - name: Install
-        uses: dtolnay/rust-toolchain@stable
+      - name: Read Rust toolchain version
+        id: rust-toolchain
+        run: echo "channel=$(grep 'channel' rust-toolchain.toml | sed 's/.*= *"\(.*\)"/\1/')" >> $GITHUB_OUTPUT
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
           targets: ${{ matrix.settings.target }}
       - name: Cache cargo
         uses: actions/cache@v4

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel    = "1.95"
-components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel    = "1.95"
+components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel    = "1.95"
+channel    = "1.95.0"
 components = ["clippy", "rustfmt"]

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -617,33 +617,33 @@ impl WorkspaceAnalyzer {
 
     for node in file_data.semantic.nodes().iter() {
       match node.kind() {
-        AstKind::StaticMemberExpression(member_expr) => {
-          if member_expr.property.name.as_str() == property_name {
-            if let Expression::Identifier(ident) = &member_expr.object {
-              if ident.name.as_str() == namespace_name {
-                let span = member_expr.span;
-                let (line, column) = self.span_to_line_col(&file_data.source, span);
-                references.push(Reference {
-                  file_path: file_path.to_path_buf(),
-                  line,
-                  column,
-                });
-              }
+        AstKind::StaticMemberExpression(member_expr)
+          if member_expr.property.name.as_str() == property_name =>
+        {
+          if let Expression::Identifier(ident) = &member_expr.object {
+            if ident.name.as_str() == namespace_name {
+              let span = member_expr.span;
+              let (line, column) = self.span_to_line_col(&file_data.source, span);
+              references.push(Reference {
+                file_path: file_path.to_path_buf(),
+                line,
+                column,
+              });
             }
           }
         }
-        AstKind::TSQualifiedName(qualified_name) => {
-          if qualified_name.right.name.as_str() == property_name {
-            if let oxc_ast::ast::TSTypeName::IdentifierReference(ident) = &qualified_name.left {
-              if ident.name.as_str() == namespace_name {
-                let span = qualified_name.span;
-                let (line, column) = self.span_to_line_col(&file_data.source, span);
-                references.push(Reference {
-                  file_path: file_path.to_path_buf(),
-                  line,
-                  column,
-                });
-              }
+        AstKind::TSQualifiedName(qualified_name)
+          if qualified_name.right.name.as_str() == property_name =>
+        {
+          if let oxc_ast::ast::TSTypeName::IdentifierReference(ident) = &qualified_name.left {
+            if ident.name.as_str() == namespace_name {
+              let span = qualified_name.span;
+              let (line, column) = self.span_to_line_col(&file_data.source, span);
+              references.push(Reference {
+                file_path: file_path.to_path_buf(),
+                line,
+                column,
+              });
             }
           }
         }
@@ -977,50 +977,38 @@ impl WorkspaceAnalyzer {
           top_level_name = Some("default".to_string());
         }
         // Top-level declarations that can be exported
-        AstKind::Function(func) => {
-          if !found_export_wrapper {
-            if let Some(id) = &func.id {
-              top_level_name = Some(id.name.to_string());
-            }
+        AstKind::Function(func) if !found_export_wrapper => {
+          if let Some(id) = &func.id {
+            top_level_name = Some(id.name.to_string());
           }
         }
-        AstKind::Class(class) => {
-          if !found_export_wrapper {
-            if let Some(id) = &class.id {
-              top_level_name = Some(id.name.to_string());
-            }
+        AstKind::Class(class) if !found_export_wrapper => {
+          if let Some(id) = &class.id {
+            top_level_name = Some(id.name.to_string());
           }
         }
-        AstKind::TSInterfaceDeclaration(interface) => {
-          if !found_export_wrapper {
-            top_level_name = Some(interface.id.name.to_string());
-          }
+        AstKind::TSInterfaceDeclaration(interface) if !found_export_wrapper => {
+          top_level_name = Some(interface.id.name.to_string());
         }
-        AstKind::TSTypeAliasDeclaration(type_alias) => {
-          if !found_export_wrapper {
-            top_level_name = Some(type_alias.id.name.to_string());
-          }
+        AstKind::TSTypeAliasDeclaration(type_alias) if !found_export_wrapper => {
+          top_level_name = Some(type_alias.id.name.to_string());
         }
-        AstKind::TSEnumDeclaration(enum_decl) => {
-          if !found_export_wrapper {
-            top_level_name = Some(enum_decl.id.name.to_string());
-          }
+        AstKind::TSEnumDeclaration(enum_decl) if !found_export_wrapper => {
+          top_level_name = Some(enum_decl.id.name.to_string());
         }
-        AstKind::VariableDeclarator(var_decl) => {
+        AstKind::VariableDeclarator(var_decl) if !found_export_wrapper => {
           // For const/let declarations, get the binding name
-          if !found_export_wrapper {
-            if let oxc_ast::ast::BindingPatternKind::BindingIdentifier(ident) = &var_decl.id.kind {
-              top_level_name = Some(ident.name.to_string());
-            }
+          if let oxc_ast::ast::BindingPatternKind::BindingIdentifier(ident) = &var_decl.id.kind {
+            top_level_name = Some(ident.name.to_string());
           }
         }
-        AstKind::VariableDeclaration(var_decl) => {
+        AstKind::VariableDeclaration(var_decl)
+          if !found_export_wrapper && top_level_name.is_none() =>
+        {
           // Same rationale as the initial-node check: when walking up from a position
           // inside the `const`/`let`/`var` keyword we hit VariableDeclaration before
           // VariableDeclarator (its child).
-          if !found_export_wrapper && top_level_name.is_none() {
-            top_level_name = Self::first_binding_name_from_var_decl(var_decl);
-          }
+          top_level_name = Self::first_binding_name_from_var_decl(var_decl);
         }
         _ => {}
       }


### PR DESCRIPTION
## Summary

- Fixes 9 `collapsible_match` clippy errors surfaced by Rust 1.95 in `src/semantic/analyzer.rs`
- Adds `rust-toolchain.toml` pinned to 1.95 so future toolchain updates are intentional

## Changes

**`src/semantic/analyzer.rs`** — purely mechanical transformations, no logic changes:

- Converts `if` blocks inside match arms to match guards (`if condition =>`)
- 2 fixes in `find_namespace_references` (lines 620, 635): lifted scalar equality checks into guards
- 7 fixes in `find_node_at_line` walk-up loop (lines 980-1024): lifted `!found_export_wrapper` checks into guards

**`rust-toolchain.toml`** — new file:

```toml
[toolchain]
channel = "1.95"
components = ["clippy", "rustfmt"]
```

Pinning prevents surprise CI failures when Rust stable auto-bumps and introduces new lints. Future toolchain updates become intentional PRs.

## Context

CI started failing on PRs #61 and #63 because `dtolnay/rust-toolchain@stable` picked up Rust 1.95 which promoted `collapsible_match` detection. The lint is `deny` via `#![deny(clippy::all)]` in `src/lib.rs`.

## Test plan

- [x] All 181 unit tests pass
- [x] Clippy clean locally (1.91)
- [x] `cargo fmt -- --check` clean
- [x] Rust specialist verified all 9 changes are semantically equivalent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization patterns in the semantic analyzer.

* **Chores**
  * Updated CI/CD toolchain configuration for development builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->