### PR TITLE
feat(ci): auto-cleanup PR preview releases

### DIFF
--- a/.github/workflows/cleanup-preview-release.yml
+++ b/.github/workflows/cleanup-preview-release.yml
@@ -1,0 +1,83 @@
+name: Cleanup Preview Release
+
+# Triggered when a PR is closed (merged or unmerged). Removes every preview
+# release created for this PR (tags matching pr-{number}-*) along with the
+# underlying git tag refs. Acts as a backstop to the in-PR cleanup that
+# preview-release.yml does on each new publish.
+'on':
+  pull_request:
+    types: [closed]
+
+  # Manual re-run for stragglers: race between PR close and an in-flight
+  # preview publish, or backfilling prior PRs whose previews were never swept.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number whose preview releases should be cleaned up'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+# Serialize per-PR so close -> reopen -> close doesn't race itself.
+concurrency:
+  group: cleanup-preview-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Delete preview releases
+    if: github.repository == 'frontops-dev/domino'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+    steps:
+      - name: Delete preview releases for this PR
+        run: |
+          set -euo pipefail
+
+          if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number: ${PR_NUMBER}" >&2
+            exit 1
+          fi
+
+          echo "Scanning for tags matching pr-${PR_NUMBER}-*"
+
+          # Server-side prefix match. Trailing dash disambiguates pr-1- from pr-12-.
+          mapfile -t tags < <(
+            gh api "repos/${GH_REPO}/git/matching-refs/tags/pr-${PR_NUMBER}-" \
+              --jq '.[].ref' 2>/dev/null \
+              | sed 's|^refs/tags/||'
+          )
+
+          if [ "${#tags[@]}" -eq 0 ]; then
+            echo "Nothing to clean up."
+            exit 0
+          fi
+
+          echo "Found ${#tags[@]} matching release(s):"
+          printf '  %s\n' "${tags[@]}"
+
+          failures=0
+          for tag in "${tags[@]}"; do
+            echo
+            echo "Deleting $tag..."
+            if gh release delete "$tag" --yes --cleanup-tag --repo "${GH_REPO}"; then
+              echo "  ok: deleted $tag"
+            else
+              echo "  fail: $tag" >&2
+              failures=$((failures + 1))
+            fi
+          done
+
+          echo
+          echo "Summary for PR #${PR_NUMBER}:"
+          echo "  Releases processed: ${#tags[@]}"
+          echo "  Failures:           ${failures}"
+
+          if [ "$failures" -gt 0 ]; then
+            exit 1
+          fi

--- a/.github/workflows/cleanup-preview-release.yml
+++ b/.github/workflows/cleanup-preview-release.yml
@@ -46,12 +46,23 @@ jobs:
 
           echo "Scanning for tags matching pr-${PR_NUMBER}-*"
 
-          # Server-side prefix match. Trailing dash disambiguates pr-1- from pr-12-.
-          mapfile -t tags < <(
-            gh api "repos/${GH_REPO}/git/matching-refs/tags/pr-${PR_NUMBER}-" \
-              --jq '.[].ref' 2>/dev/null \
-              | sed 's|^refs/tags/||'
-          )
+          # Capture API output and exit status explicitly. Without this, an API
+          # failure inside `< <(... | sed)` silently produces an empty result
+          # which would be misread as "no matches found" — and the backstop
+          # workflow would falsely report success while leaving releases behind.
+          # Server-side prefix match; trailing dash disambiguates pr-1- from pr-12-.
+          if ! api_refs=$(gh api "repos/${GH_REPO}/git/matching-refs/tags/pr-${PR_NUMBER}-" --jq '.[].ref'); then
+            echo "ERROR: failed to query matching tags via gh api; aborting cleanup" >&2
+            exit 1
+          fi
+
+          tags=()
+          if [ -n "$api_refs" ]; then
+            while IFS= read -r ref; do
+              [ -z "$ref" ] && continue
+              tags+=("${ref#refs/tags/}")
+            done <<< "$api_refs"
+          fi
 
           if [ "${#tags[@]}" -eq 0 ]; then
             echo "Nothing to clean up."

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -95,17 +95,30 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
+          set -euo pipefail
+          # Capture API output and exit status explicitly. A pipe-into-loop
+          # would mask a gh api failure (network blip, rate limit) as an
+          # empty result — leaving stale previews while the publish step
+          # still creates a new one. Warn-and-continue here because the
+          # close-time workflow is the authoritative backstop.
           # Server-side prefix match; trailing dash disambiguates pr-1- from pr-12-.
-          # Failures here are non-fatal: the close-time workflow is the backstop.
-          gh api "repos/${GH_REPO}/git/matching-refs/tags/pr-${PR_NUMBER}-" \
-            --jq '.[].ref' 2>/dev/null \
-            | sed 's|^refs/tags/||' \
-            | while read -r tag; do
-                [ -z "$tag" ] && continue
-                echo "Deleting prior preview release ${tag}"
-                gh release delete "${tag}" --yes --cleanup-tag --repo "${GH_REPO}" \
-                  || echo "WARN: failed to delete ${tag} (continuing; close-time workflow is the backstop)" >&2
-              done
+          if ! api_refs=$(gh api "repos/${GH_REPO}/git/matching-refs/tags/pr-${PR_NUMBER}-" --jq '.[].ref'); then
+            echo "WARN: failed to query prior preview tags via gh api; skipping in-PR cleanup (close-time workflow will handle it)" >&2
+            exit 0
+          fi
+
+          if [ -z "$api_refs" ]; then
+            echo "No prior previews to delete."
+            exit 0
+          fi
+
+          while IFS= read -r ref; do
+            [ -z "$ref" ] && continue
+            tag="${ref#refs/tags/}"
+            echo "Deleting prior preview release ${tag}"
+            gh release delete "${tag}" --yes --cleanup-tag --repo "${GH_REPO}" \
+              || echo "WARN: failed to delete ${tag} (continuing; close-time workflow is the backstop)" >&2
+          done <<< "$api_refs"
 
       - name: Create GitHub Release
         uses: actions/github-script@v7

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -46,8 +46,20 @@ jobs:
       - name: Read PR metadata
         id: pr
         run: |
-          echo "number=$(jq -r .pr_number pr-metadata.json)" >> "$GITHUB_OUTPUT"
-          echo "head_sha=$(jq -r .head_sha pr-metadata.json)" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          pr_number=$(jq -r .pr_number pr-metadata.json)
+          head_sha=$(jq -r .head_sha pr-metadata.json)
+          # Defense-in-depth: validate before using in shell/scripts downstream.
+          if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+            echo "Invalid pr_number from pr-metadata.json: $pr_number" >&2
+            exit 1
+          fi
+          if ! [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid head_sha from pr-metadata.json: $head_sha" >&2
+            exit 1
+          fi
+          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
 
       - name: Download all build artifacts
         uses: actions/download-artifact@v4
@@ -91,7 +103,8 @@ jobs:
             | while read -r tag; do
                 [ -z "$tag" ] && continue
                 echo "Deleting prior preview release ${tag}"
-                gh release delete "${tag}" --yes --cleanup-tag --repo "${GH_REPO}" || true
+                gh release delete "${tag}" --yes --cleanup-tag --repo "${GH_REPO}" \
+                  || echo "WARN: failed to delete ${tag} (continuing; close-time workflow is the backstop)" >&2
               done
 
       - name: Create GitHub Release

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -20,6 +20,9 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
+    concurrency:
+      group: preview-release-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v6
 
@@ -43,8 +46,8 @@ jobs:
       - name: Read PR metadata
         id: pr
         run: |
-          echo "number=$(jq -r .pr_number pr-metadata.json)" >> $GITHUB_OUTPUT
-          echo "head_sha=$(jq -r .head_sha pr-metadata.json)" >> $GITHUB_OUTPUT
+          echo "number=$(jq -r .pr_number pr-metadata.json)" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(jq -r .head_sha pr-metadata.json)" >> "$GITHUB_OUTPUT"
 
       - name: Download all build artifacts
         uses: actions/download-artifact@v4
@@ -72,7 +75,24 @@ jobs:
       - name: Read manifest
         id: manifest
         run: |
-          echo "data=$(cat manifest.json | jq -c)" >> $GITHUB_OUTPUT
+          echo "data=$(cat manifest.json | jq -c)" >> "$GITHUB_OUTPUT"
+
+      - name: Delete prior preview releases for this PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          # Server-side prefix match; trailing dash disambiguates pr-1- from pr-12-.
+          # Failures here are non-fatal: the close-time workflow is the backstop.
+          gh api "repos/${GH_REPO}/git/matching-refs/tags/pr-${PR_NUMBER}-" \
+            --jq '.[].ref' 2>/dev/null \
+            | sed 's|^refs/tags/||' \
+            | while read -r tag; do
+                [ -z "$tag" ] && continue
+                echo "Deleting prior preview release ${tag}"
+                gh release delete "${tag}" --yes --cleanup-tag --repo "${GH_REPO}" || true
+              done
 
       - name: Create GitHub Release
         uses: actions/github-script@v7


### PR DESCRIPTION
Closes #11

## Problem

Every commit to a PR publishes a GitHub Release tagged `pr-{N}-{sha}` with platform tarballs. These releases are never deleted, so each PR leaves behind one release per commit, and after the PR closes they linger forever — cluttering the Releases page and making real production releases hard to find.

## Solution

Two cleanup paths, both using `gh api git/matching-refs/tags/pr-{N}-` (server-side prefix match, no pagination) and `gh release delete --cleanup-tag --yes` (release + git tag in one call).

### `preview-release.yml` (modified)
- Adds per-PR `concurrency` with `cancel-in-progress: true`, so rapid pushes don't queue stale publishes.
- Inserts a "Delete prior preview releases" step *before* the new release is created — keeps the Releases page reflecting only the latest preview per open PR.
- Validates `pr_number` (numeric) and `head_sha` (40-char hex) read from the `pr-metadata.json` artifact before they flow into shell/Node — defense-in-depth.
- The new ``gh release delete`` step uses `|| echo "WARN: ..." >&2` instead of `|| true` so token-scope regressions don't go silent.

### `cleanup-preview-release.yml` (new)
- Triggers on `pull_request: closed` (covers merge and close-without-merge).
- Also exposes `workflow_dispatch` with a `pr_number` input — manual escape hatch for backfilling existing accumulated releases (per discussion on #11) and for the rare close-mid-publish race.
- Counts failures explicitly and exits non-zero if anything failed, so the Actions tab surfaces problems.

Reference: same shape as [coralogix/protofetch#196](https://github.com/coralogix/protofetch/pull/196). The cleanup mechanism is borrowed; the existing tag format `pr-{N}-{sha}` is kept as-is (the trailing `-` already disambiguates `pr-1-` from `pr-12-`).

## Outcome

- At most one preview release per *open* PR.
- Zero preview releases after the PR closes.

## Testing performed

- ``actionlint`` on both workflow files: clean.
- ``cargo fmt --all -- --check``, ``cargo clippy --all-targets --all-features -- -D warnings``, ``cargo test --lib``: all pass.
- ``cargo test --test integration_test``: pre-existing local NAPI linker error on macOS arm64 (reproduces on ``main``); unrelated to this YAML-only change.
- Security review surfaced two findings, both fixed in the second commit.

## Validation plan after merge

1. **In-PR cleanup**: open a throwaway PR, push 2–3 commits; Releases page should only ever show the latest ``pr-{N}-{sha}``.
2. **Concurrency cancellation**: push two commits quickly; the first publish run should appear cancelled in the Actions tab.
3. **Merge path**: merge the PR; ``Cleanup Preview Release`` should remove the final remaining release + tag.
4. **Close-unmerged path**: open another PR, get a preview, close without merging; same verification.
5. **Backfill**: run ``workflow_dispatch`` with each old PR's number to clean up existing accumulated releases.

## Breaking changes

None. The tag format is unchanged; the publish flow is unchanged externally; existing PR comments continue to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with improved concurrency handling for preview releases to prevent conflicting simultaneous runs
  * Added automatic cleanup of preview releases and associated tags when pull requests are closed
  * Strengthened input validation and error handling in the release workflow process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->