### PR TITLE
fix: treat dynamic imports with static specifiers like static namespace imports

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -756,7 +756,7 @@ fn process_changed_symbol(
       }
     }
 
-    // Special case: line=0,column=0 is a sentinel for "entire file affected" (from dynamic imports)
+    // Special case: line=0,column=0 is a sentinel for "entire file affected"
     // In this case, we need to process all exports from that file
     if reference.line == 0 && reference.column == 0 {
       debug!(

--- a/src/core.rs
+++ b/src/core.rs
@@ -760,7 +760,7 @@ fn process_changed_symbol(
     // In this case, we need to process all exports from that file
     if reference.line == 0 && reference.column == 0 {
       debug!(
-        "File {:?} is conservatively affected (dynamic import). Processing all its exports.",
+        "File {:?} is conservatively affected (entire-file sentinel). Processing all its exports.",
         reference.file_path
       );
 

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -366,8 +366,9 @@ impl<'a> Visit<'a> for DynamicImportVisitor<'a> {
         self.dynamic_count += 1;
       }
       _ => {
-        // Non-string-literal imports (template literals, variables, etc.)
-        // are not currently supported. These would require runtime evaluation.
+        // TODO(#68): non-string-literal specifiers (template literals, variables)
+        // are silently dropped — importers will never be marked affected.
+        // Consider conservative treatment or pattern-matching common forms.
         warn!(
           "Skipping dynamic import with non-string-literal specifier (template literal or variable). \
            Only string literal dynamic imports are currently supported for affected analysis."

--- a/src/semantic/reference_finder.rs
+++ b/src/semantic/reference_finder.rs
@@ -170,24 +170,23 @@ impl<'a> ReferenceFinder<'a> {
               );
               all_refs.extend(member_refs);
             } else if *is_dynamic {
-              // Dynamic imports (from import() expressions) get conservative treatment:
-              // Even if we can't find local references to the synthetic namespace identifier
-              // (like __dynamic_import_0), we still mark the file as affected because
-              // the dynamic import likely uses the module in ways we can't statically analyze
-              // (e.g., import('module').then(m => m.Component))
+              // Dynamic imports with string literal specifiers (which is all tracked dynamic
+              // imports — non-string-literal ones are skipped during extraction) are treated
+              // like static namespace imports: if we can't find member access to the specific
+              // changed symbol, we don't mark the file as affected.
+              //
+              // This prevents React.lazy(() => import('./SomePage')) from cascading all
+              // exports when a deep dependency of SomePage changes. The lazy boundary
+              // acts as an isolation point — only explicit member access propagates.
               debug!(
-                "No local references to dynamic namespace '{}', but marking file {:?} as affected (conservative)",
-                local_name, importing_file
+                "No local references to dynamic namespace '{}' for symbol '{}' in {:?} — \
+                 specifier is a static string literal, treating like static namespace import (no cascade)",
+                local_name, symbol_name, importing_file
               );
-              all_refs.push(Reference {
-                file_path: importing_file.clone(),
-                line: 0,   // Sentinel value: line 0 indicates "entire file affected"
-                column: 0, // Sentinel value: column 0 with line 0
-              });
             }
-            // For static namespace imports (import * as foo), if we don't find any references
-            // to 'foo.symbol', we don't mark the file as affected (strict behavior) since the
-            // namespace either doesn't use this specific symbol or is dead code.
+            // For both static and dynamic namespace imports, if we don't find any references
+            // to 'namespace.symbol', we don't mark the file as affected (strict behavior)
+            // since the namespace either doesn't use this specific symbol or is dead code.
           }
           Err(e) => {
             // Propagate the error instead of silently marking as affected

--- a/src/types.rs
+++ b/src/types.rs
@@ -112,8 +112,9 @@ pub struct Import {
   /// Whether this is a type-only import
   #[allow(dead_code)]
   pub is_type_only: bool,
-  /// Whether this import comes from a dynamic import() expression
-  /// Dynamic imports get conservative treatment for namespace resolution
+  /// Whether this import comes from a dynamic import() expression.
+  /// Dynamic imports with string literal specifiers are treated like static
+  /// namespace imports — only explicit member access propagates changes.
   pub is_dynamic: bool,
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -796,6 +796,13 @@ export function getTheme() {
 fn test_dynamic_import_detection() {
   let branch = TestBranch::new("test-dynamic-import");
 
+  // Guard: verify the baseline fixture file exists — without it, the negative
+  // assertion below would pass vacuously (no dynamic import = no cascade to block).
+  assert!(
+    fixture_path().join("proj2/lazy-loader.tsx").exists(),
+    "Fixture file proj2/lazy-loader.tsx must exist on main for this test to be meaningful"
+  );
+
   // proj2/lazy-loader.tsx already exists in the baseline with a React.lazy dynamic import from proj1.
   // Change proj1 - proj2 should NOT be affected because the dynamic import
   // with a static string specifier acts as an isolation boundary (no conservative cascade)
@@ -833,6 +840,13 @@ export function unusedFn() {
 #[test]
 fn test_multiple_dynamic_imports() {
   let branch = TestBranch::new("test-multiple-dynamic-imports");
+
+  // Guard: verify the baseline fixture file exists — without it, the test
+  // would pass vacuously since there would be no dynamic imports to isolate.
+  assert!(
+    fixture_path().join("proj3/dynamic-loader.tsx").exists(),
+    "Fixture file proj3/dynamic-loader.tsx must exist on main for this test to be meaningful"
+  );
 
   // proj3/dynamic-loader.tsx already exists in the baseline with multiple dynamic imports
   // from proj1 and proj2.
@@ -926,6 +940,13 @@ export class MyClass {
 #[test]
 fn test_dynamic_import_static_specifier_no_cascade() {
   let branch = TestBranch::new("test-dynamic-no-cascade");
+
+  // Guard: verify the baseline fixture file exists — without it, the negative
+  // assertion below would pass vacuously (no dynamic import = no cascade to block).
+  assert!(
+    fixture_path().join("proj2/page-wrapper.tsx").exists(),
+    "Fixture file proj2/page-wrapper.tsx must exist on main for this test to be meaningful"
+  );
 
   // proj2/page-wrapper.tsx already exists in baseline with React.lazy(() => import('@monorepo/proj1')).
   // proj3 statically imports from proj2 (baseline index.ts imports anotherFn from proj2).

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -796,25 +796,9 @@ export function getTheme() {
 fn test_dynamic_import_detection() {
   let branch = TestBranch::new("test-dynamic-import");
 
-  // Add a file to proj2 that uses dynamic import from proj1
-  branch.make_change(
-    "proj2/lazy-loader.tsx",
-    r#"import React from 'react';
-
-// Dynamic import using React.lazy
-const LazyProj1Component = React.lazy(
-  () => import('@monorepo/proj1').then(m => ({ default: m.proj1 }))
-);
-
-export function LazyLoader() {
-  return <React.Suspense fallback={<div>Loading...</div>}>
-    <LazyProj1Component />
-  </React.Suspense>;
-}
-"#,
-  );
-
-  // Now change proj1 - proj2 should be affected due to dynamic import
+  // proj2/lazy-loader.tsx already exists in the baseline with a React.lazy dynamic import from proj1.
+  // Change proj1 - proj2 should NOT be affected because the dynamic import
+  // with a static string specifier acts as an isolation boundary (no conservative cascade)
   branch.make_change(
     "proj1/index.ts",
     r#"export function proj1() {
@@ -829,14 +813,16 @@ export function unusedFn() {
 
   let affected = branch.get_affected();
 
-  // proj1 changed, proj2 has a dynamic import of proj1, proj3 has implicit dependency
+  // proj1 changed, proj3 has implicit dependency on proj1
+  // proj2 has a React.lazy() dynamic import from proj1 with a static string specifier,
+  // so changes do NOT cascade through the lazy boundary
   assert!(
     affected.contains(&"proj1".to_string()),
     "proj1 should be affected (changed)"
   );
   assert!(
-    affected.contains(&"proj2".to_string()),
-    "proj2 should be affected (has dynamic import from proj1)"
+    !affected.contains(&"proj2".to_string()),
+    "proj2 should NOT be affected (React.lazy dynamic import is an isolation boundary)"
   );
   assert!(
     affected.contains(&"proj3".to_string()),
@@ -848,23 +834,8 @@ export function unusedFn() {
 fn test_multiple_dynamic_imports() {
   let branch = TestBranch::new("test-multiple-dynamic-imports");
 
-  // Add a file with multiple dynamic imports
-  branch.make_change(
-    "proj3/dynamic-loader.tsx",
-    r#"import React from 'react';
-
-const Component1 = React.lazy(() => import('@monorepo/proj1'));
-const Component2 = React.lazy(() => import('@monorepo/proj2'));
-
-async function loadModules() {
-  const mod1 = await import('@monorepo/proj1');
-  const mod2 = await import('@monorepo/proj2');
-  return { mod1, mod2 };
-}
-
-export { Component1, Component2, loadModules };
-"#,
-  );
+  // proj3/dynamic-loader.tsx already exists in the baseline with multiple dynamic imports
+  // from proj1 and proj2.
 
   // Change proj1
   branch.make_change(
@@ -881,14 +852,16 @@ export function unusedFn() {
 
   let affected = branch.get_affected();
 
-  // proj1 changed, proj3 dynamically imports it
+  // proj1 changed, but proj3's dynamic imports with static string specifiers
+  // do NOT cascade — the lazy boundary acts as isolation.
+  // proj3 IS affected because it has an implicit dependency on proj1.
   assert!(
     affected.contains(&"proj1".to_string()),
     "proj1 should be affected"
   );
   assert!(
     affected.contains(&"proj3".to_string()),
-    "proj3 should be affected (has dynamic imports from proj1)"
+    "proj3 should be affected (implicit dependency on proj1)"
   );
 }
 
@@ -947,6 +920,45 @@ export class MyClass {
   assert!(
     !affected.contains(&"proj1".to_string()),
     "proj1 should NOT be affected (it didn't change)"
+  );
+}
+
+#[test]
+fn test_dynamic_import_static_specifier_no_cascade() {
+  let branch = TestBranch::new("test-dynamic-no-cascade");
+
+  // proj2/page-wrapper.tsx already exists in baseline with React.lazy(() => import('@monorepo/proj1')).
+  // proj3 statically imports from proj2 (baseline index.ts imports anotherFn from proj2).
+  // When proj1 changes, the cascade should stop at the lazy boundary:
+  // proj1 is affected (changed), but proj2 is NOT (lazy boundary).
+
+  // Change proj1 — should NOT cascade through the lazy boundary to proj2
+  branch.make_change(
+    "proj1/index.ts",
+    r#"export function proj1() {
+  return 'proj1-changed-deep';
+}
+
+export function unusedFn() {
+  return 'unusedFn';
+}
+"#,
+  );
+
+  let affected = branch.get_affected();
+
+  assert!(
+    affected.contains(&"proj1".to_string()),
+    "proj1 should be affected (changed)"
+  );
+  assert!(
+    !affected.contains(&"proj2".to_string()),
+    "proj2 should NOT be affected (React.lazy is an isolation boundary)"
+  );
+  // proj3 has implicit dep on proj1, so it IS affected through that path
+  assert!(
+    affected.contains(&"proj3".to_string()),
+    "proj3 should be affected (implicit dependency on proj1)"
   );
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -205,9 +205,9 @@ export function unusedFn() {
 
   let affected = branch.get_affected();
 
-  // proj1 changed, proj2 uses it via import, and proj3 has implicit dependency on proj1
-  // Note: implicit dependencies cause proj3 to be affected even if the specific function isn't used
+  // proj1 changed, proj2 imports proj1() via static import, proj3 has implicit dep on proj1
   assert!(affected.contains(&"proj1".to_string()));
+  assert!(affected.contains(&"proj2".to_string()));
   assert!(affected.contains(&"proj3".to_string())); // implicit dependency
 }
 
@@ -810,32 +810,33 @@ fn test_react_lazy_no_cascade() {
   );
 
   // proj2/lazy-loader.tsx already exists in the baseline with a React.lazy dynamic import from proj1.
-  // Change proj1 - proj2 should NOT be affected because the dynamic import
-  // with a static string specifier acts as an isolation boundary (no conservative cascade)
+  // Change ONLY unusedFn (which nobody statically imports) to isolate the dynamic import behavior.
+  // If dynamic imports cascaded conservatively, proj2 would be marked affected here.
   branch.make_change(
     "proj1/index.ts",
     r#"export function proj1() {
-  return 'proj1-modified-for-dynamic-import';
+  return 'proj1';
 }
 
 export function unusedFn() {
-  return 'unusedFn';
+  return 'unusedFn-changed';
 }
 "#,
   );
 
   let affected = branch.get_affected();
 
-  // proj1 changed, proj3 has implicit dependency on proj1
-  // proj2 has a React.lazy() dynamic import from proj1 with a static string specifier,
-  // so changes do NOT cascade through the lazy boundary
+  // proj1 changed (unusedFn modified), proj3 has implicit dependency on proj1.
+  // proj2 has a React.lazy dynamic import from proj1 — the lazy boundary
+  // blocks cascade of unusedFn through the dynamic import.
+  // proj2/index.ts statically imports proj1() but that symbol didn't change.
   assert!(
     affected.contains(&"proj1".to_string()),
     "proj1 should be affected (changed)"
   );
   assert!(
     !affected.contains(&"proj2".to_string()),
-    "proj2 should NOT be affected (React.lazy dynamic import is an isolation boundary)"
+    "proj2 should NOT be affected (unusedFn is not statically imported, and the dynamic import boundary blocks cascade)"
   );
   assert!(
     affected.contains(&"proj3".to_string()),
@@ -866,24 +867,24 @@ fn test_multiple_dynamic_imports() {
   // proj3/dynamic-loader.tsx already exists in the baseline with multiple dynamic imports
   // from proj1 and proj2.
 
-  // Change proj1
+  // Change ONLY unusedFn to isolate the dynamic import behavior.
   branch.make_change(
     "proj1/index.ts",
     r#"export function proj1() {
-  return 'proj1-updated';
+  return 'proj1';
 }
 
 export function unusedFn() {
-  return 'unusedFn';
+  return 'unusedFn-multi-dynamic-test';
 }
 "#,
   );
 
   let affected = branch.get_affected();
 
-  // proj1 changed, but proj3's dynamic imports with static string specifiers
-  // do NOT cascade — the lazy boundary acts as isolation.
-  // proj3 IS affected because it has an implicit dependency on proj1 (see get_affected config).
+  // proj1 changed (unusedFn), but the dynamic import boundaries block cascade.
+  // proj2 is not affected (proj3's dynamic imports don't cascade to proj2).
+  // proj3 IS affected via implicit dependency on proj1 (see get_affected config).
   assert!(
     affected.contains(&"proj1".to_string()),
     "proj1 should be affected"
@@ -974,18 +975,17 @@ fn test_dynamic_import_static_specifier_no_cascade() {
 
   // proj2/page-wrapper.tsx already exists in baseline with React.lazy(() => import('@monorepo/proj1')).
   // proj3 statically imports from proj2 (baseline index.ts imports anotherFn from proj2).
-  // When proj1 changes, the cascade should stop at the lazy boundary:
-  // proj1 is affected (changed), but proj2 is NOT (lazy boundary).
-
-  // Change proj1 — should NOT cascade through the lazy boundary to proj2
+  // Change ONLY unusedFn — proj2/index.ts statically imports proj1() but NOT unusedFn,
+  // so the only way unusedFn could cascade to proj2 is through the dynamic import.
+  // The lazy boundary should block it.
   branch.make_change(
     "proj1/index.ts",
     r#"export function proj1() {
-  return 'proj1-changed-deep';
+  return 'proj1';
 }
 
 export function unusedFn() {
-  return 'unusedFn';
+  return 'unusedFn-cascade-test';
 }
 "#,
   );
@@ -998,7 +998,7 @@ export function unusedFn() {
   );
   assert!(
     !affected.contains(&"proj2".to_string()),
-    "proj2 should NOT be affected (React.lazy is an isolation boundary)"
+    "proj2 should NOT be affected (unusedFn not statically imported, dynamic import boundary blocks cascade)"
   );
   // proj3 is affected via implicit_dependencies: ["proj1"] in the test config (see get_affected)
   assert!(
@@ -1011,25 +1011,24 @@ export function unusedFn() {
 fn test_dynamic_import_coexists_with_static_import() {
   let branch = TestBranch::new("test-dynamic-static-coexist");
 
-  // Add a file in proj2 that has BOTH a static named import and a dynamic import from proj1.
-  // The static import should still cascade when proj1 changes, proving that
-  // the presence of dynamic imports doesn't suppress static import detection.
-  branch.make_change(
-    "proj2/mixed-imports.ts",
-    r#"import { proj1 } from '@monorepo/proj1';
-
-export async function loadLazy() {
-  const mod = await import('@monorepo/proj1');
-  return mod;
-}
-
-export function useStatic() {
-  return proj1();
-}
-"#,
+  // Guard: proj2/mixed-imports.ts must exist in baseline with both import styles.
+  let mixed = fixture_path().join("proj2/mixed-imports.ts");
+  assert!(
+    mixed.exists(),
+    "Fixture file proj2/mixed-imports.ts must exist on main for this test to be meaningful"
+  );
+  let content = fs::read_to_string(&mixed).unwrap();
+  assert!(
+    content.contains("import { proj1 } from '@monorepo/proj1'"),
+    "proj2/mixed-imports.ts must contain a static import from proj1"
+  );
+  assert!(
+    content.contains("import('@monorepo/proj1')"),
+    "proj2/mixed-imports.ts must contain a dynamic import from proj1"
   );
 
-  // Change proj1
+  // Only change proj1 — mixed-imports.ts is already committed on main,
+  // so the diff only contains the proj1 modification.
   branch.make_change(
     "proj1/index.ts",
     r#"export function proj1() {
@@ -1048,11 +1047,12 @@ export function unusedFn() {
     affected.contains(&"proj1".to_string()),
     "proj1 should be affected (changed)"
   );
-  // proj2 is affected: mixed-imports.ts is new on the branch (in the diff) and
-  // its static import of proj1 creates a reference to the changed symbol.
+  // proj2 is affected through the STATIC import in mixed-imports.ts.
+  // The dynamic import in the same file doesn't cascade (isolation boundary),
+  // but the static import `import { proj1 }` still propagates the change.
   assert!(
     affected.contains(&"proj2".to_string()),
-    "proj2 should be affected (mixed-imports.ts has a static import of the changed symbol)"
+    "proj2 should be affected (static import in mixed-imports.ts references the changed symbol)"
   );
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -793,14 +793,20 @@ export function getTheme() {
 }
 
 #[test]
-fn test_dynamic_import_detection() {
+fn test_react_lazy_no_cascade() {
   let branch = TestBranch::new("test-dynamic-import");
 
-  // Guard: verify the baseline fixture file exists — without it, the negative
-  // assertion below would pass vacuously (no dynamic import = no cascade to block).
+  // Guard: verify the baseline fixture exists and contains the expected dynamic import.
+  // Without it, the negative assertion below would pass vacuously.
+  let lazy_loader = fixture_path().join("proj2/lazy-loader.tsx");
   assert!(
-    fixture_path().join("proj2/lazy-loader.tsx").exists(),
+    lazy_loader.exists(),
     "Fixture file proj2/lazy-loader.tsx must exist on main for this test to be meaningful"
+  );
+  let content = fs::read_to_string(&lazy_loader).unwrap();
+  assert!(
+    content.contains("import('@monorepo/proj1')"),
+    "proj2/lazy-loader.tsx must contain a dynamic import from proj1"
   );
 
   // proj2/lazy-loader.tsx already exists in the baseline with a React.lazy dynamic import from proj1.
@@ -841,11 +847,20 @@ export function unusedFn() {
 fn test_multiple_dynamic_imports() {
   let branch = TestBranch::new("test-multiple-dynamic-imports");
 
-  // Guard: verify the baseline fixture file exists — without it, the test
-  // would pass vacuously since there would be no dynamic imports to isolate.
+  // Guard: verify the baseline fixture exists and contains the expected dynamic imports.
+  let dynamic_loader = fixture_path().join("proj3/dynamic-loader.tsx");
   assert!(
-    fixture_path().join("proj3/dynamic-loader.tsx").exists(),
+    dynamic_loader.exists(),
     "Fixture file proj3/dynamic-loader.tsx must exist on main for this test to be meaningful"
+  );
+  let content = fs::read_to_string(&dynamic_loader).unwrap();
+  assert!(
+    content.contains("import('@monorepo/proj1')"),
+    "proj3/dynamic-loader.tsx must contain a dynamic import from proj1"
+  );
+  assert!(
+    content.contains("import('@monorepo/proj2')"),
+    "proj3/dynamic-loader.tsx must contain a dynamic import from proj2"
   );
 
   // proj3/dynamic-loader.tsx already exists in the baseline with multiple dynamic imports
@@ -868,10 +883,14 @@ export function unusedFn() {
 
   // proj1 changed, but proj3's dynamic imports with static string specifiers
   // do NOT cascade — the lazy boundary acts as isolation.
-  // proj3 IS affected because it has an implicit dependency on proj1.
+  // proj3 IS affected because it has an implicit dependency on proj1 (see get_affected config).
   assert!(
     affected.contains(&"proj1".to_string()),
     "proj1 should be affected"
+  );
+  assert!(
+    !affected.contains(&"proj2".to_string()),
+    "proj2 should NOT be affected (only referenced via dynamic imports in proj3)"
   );
   assert!(
     affected.contains(&"proj3".to_string()),
@@ -941,11 +960,16 @@ export class MyClass {
 fn test_dynamic_import_static_specifier_no_cascade() {
   let branch = TestBranch::new("test-dynamic-no-cascade");
 
-  // Guard: verify the baseline fixture file exists — without it, the negative
-  // assertion below would pass vacuously (no dynamic import = no cascade to block).
+  // Guard: verify the baseline fixture exists and contains the expected dynamic import.
+  let page_wrapper = fixture_path().join("proj2/page-wrapper.tsx");
   assert!(
-    fixture_path().join("proj2/page-wrapper.tsx").exists(),
+    page_wrapper.exists(),
     "Fixture file proj2/page-wrapper.tsx must exist on main for this test to be meaningful"
+  );
+  let content = fs::read_to_string(&page_wrapper).unwrap();
+  assert!(
+    content.contains("import('@monorepo/proj1')"),
+    "proj2/page-wrapper.tsx must contain a dynamic import from proj1"
   );
 
   // proj2/page-wrapper.tsx already exists in baseline with React.lazy(() => import('@monorepo/proj1')).
@@ -976,10 +1000,108 @@ export function unusedFn() {
     !affected.contains(&"proj2".to_string()),
     "proj2 should NOT be affected (React.lazy is an isolation boundary)"
   );
-  // proj3 has implicit dep on proj1, so it IS affected through that path
+  // proj3 is affected via implicit_dependencies: ["proj1"] in the test config (see get_affected)
   assert!(
     affected.contains(&"proj3".to_string()),
     "proj3 should be affected (implicit dependency on proj1)"
+  );
+}
+
+#[test]
+fn test_dynamic_import_coexists_with_static_import() {
+  let branch = TestBranch::new("test-dynamic-static-coexist");
+
+  // Add a file in proj2 that has BOTH a static named import and a dynamic import from proj1.
+  // The static import should still cascade when proj1 changes, proving that
+  // the presence of dynamic imports doesn't suppress static import detection.
+  branch.make_change(
+    "proj2/mixed-imports.ts",
+    r#"import { proj1 } from '@monorepo/proj1';
+
+export async function loadLazy() {
+  const mod = await import('@monorepo/proj1');
+  return mod;
+}
+
+export function useStatic() {
+  return proj1();
+}
+"#,
+  );
+
+  // Change proj1
+  branch.make_change(
+    "proj1/index.ts",
+    r#"export function proj1() {
+  return 'proj1-coexist-change';
+}
+
+export function unusedFn() {
+  return 'unusedFn';
+}
+"#,
+  );
+
+  let affected = branch.get_affected();
+
+  assert!(
+    affected.contains(&"proj1".to_string()),
+    "proj1 should be affected (changed)"
+  );
+  // proj2 is affected: mixed-imports.ts is new on the branch (in the diff) and
+  // its static import of proj1 creates a reference to the changed symbol.
+  assert!(
+    affected.contains(&"proj2".to_string()),
+    "proj2 should be affected (mixed-imports.ts has a static import of the changed symbol)"
+  );
+}
+
+#[test]
+fn test_non_string_literal_dynamic_import_no_crash() {
+  let branch = TestBranch::new("test-nonstring-dynamic");
+
+  // Template literal and variable dynamic imports should not crash or mis-cascade.
+  // These are silently skipped during extraction (logged as warnings).
+  branch.make_change(
+    "proj2/variable-import.ts",
+    r#"const moduleName = '@monorepo/proj1';
+
+export async function loadVariable() {
+  const mod = await import(moduleName);
+  return mod;
+}
+
+export async function loadTemplate() {
+  const name = 'proj1';
+  const mod = await import(`@monorepo/${name}`);
+  return mod;
+}
+"#,
+  );
+
+  branch.make_change(
+    "proj1/index.ts",
+    r#"export function proj1() {
+  return 'proj1-nonstring-test';
+}
+
+export function unusedFn() {
+  return 'unusedFn';
+}
+"#,
+  );
+
+  let affected = branch.get_affected();
+
+  // Should not crash. proj1 changed, proj2 has non-string dynamic imports
+  // which are skipped — proj2 is only affected if its own files are in the diff.
+  assert!(
+    affected.contains(&"proj1".to_string()),
+    "proj1 should be affected (changed)"
+  );
+  assert!(
+    affected.contains(&"proj2".to_string()),
+    "proj2 should be affected (variable-import.ts is a new file in the diff)"
   );
 }
 


### PR DESCRIPTION
## Summary

- **Removes the conservative fallback** for dynamic imports with string literal specifiers (e.g., `React.lazy(() => import('./SomePage'))`)
- Previously, these triggered a sentinel `(0,0)` reference that processed ALL exports from the importing file, cascading through the entire import tree
- Now they are treated like static namespace imports: only explicit `namespace.symbol` member access propagates changes
- Lazy boundaries act as isolation points, preventing a single deep change from fanning out to 20+ unrelated projects

## Key changes

- `src/semantic/reference_finder.rs`: When a dynamic import namespace has no local member access for the changed symbol, skip it instead of conservatively marking the file affected
- `tests/integration_test.rs`: Updated existing dynamic import tests to match new behavior; added `test_dynamic_import_static_specifier_no_cascade` test
- Fixture baseline updated with lazy-loader files so tests verify isolation behavior without side effects from file creation

Closes #68

## Test plan

- [x] `cargo test --lib` — 193 unit tests pass
- [x] `cargo test --test integration_test -- --test-threads=1` — 51/53 pass (2 pre-existing fixture failures unrelated to this change)
- [x] `cargo clippy --all-targets --all-features` — no warnings
- [x] `cargo fmt --check` — clean
- [x] All 3 dynamic import tests pass: `test_dynamic_import_detection`, `test_multiple_dynamic_imports`, `test_dynamic_import_static_specifier_no_cascade`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined dynamic import/namespace handling so static-string dynamic imports no longer trigger unnecessary cascading "file affected" marks when no member access is observed.

* **Tests**
  * Updated integration tests and added a new test to assert static-specifier lazy/dynamic imports do not cascade changes to unrelated projects.

* **Documentation**
  * Clarified docs describing dynamic-import behavior with string-literal specifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frontops-dev/domino/pull/69)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->