### PR TITLE
feat(report): self-explaining global-invalidation + brand revamp

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -5,14 +5,15 @@ use crate::named_inputs;
 use crate::profiler::Profiler;
 use crate::semantic::{AssetReferenceFinder, ReferenceFinder, WorkspaceAnalyzer};
 use crate::types::{
-  AffectCause, AffectedProjectInfo, AffectedReport, AffectedResult, ChangedFile, LockfileStrategy,
-  Project, TrueAffectedConfig,
+  AffectCause, AffectedProjectInfo, AffectedReport, AffectedResult, ChangedFile, GlobalTrigger,
+  LockfileStrategy, Project, ReportTotals, TrueAffectedConfig,
 };
 use crate::utils::{self, ProjectIndex};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::debug;
 
 /// Mutable state for tracking affected symbols during analysis
@@ -80,10 +81,16 @@ fn find_affected_internal(
   debug!("Base: {}", config.base);
   debug!("Projects: {}", config.projects.len());
 
+  let run_started_at_unix_secs = SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .map(|d| d.as_secs() as i64)
+    .unwrap_or(0);
+
   // Step 1: Get changed files from git (also returns the merge-base SHA)
   let (changed_files, merge_base) =
     git::get_changed_files(&config.cwd, &config.base, config.head.as_deref())?;
   debug!("Found {} changed files", changed_files.len());
+  let total_changed_files = changed_files.len();
 
   if changed_files.is_empty() {
     debug!("No changes detected");
@@ -93,35 +100,32 @@ fn find_affected_internal(
     });
   }
 
-  // Step 1b: Apply Nx namedInputs — global invalidation and negation filtering
+  // Step 1b: Apply Nx namedInputs — collect global-invalidation triggers and
+  // apply negation filtering.
+  //
+  // When --report is NOT requested, a single global trigger lets us match
+  // `nx affected` immediately without running the expensive semantic pipeline.
+  // When --report IS requested, we continue through semantic analysis even on
+  // a global run so the HTML can separate "globally invalidated" from
+  // "semantically affected" projects — the whole point of the report.
   let resolved_inputs = named_inputs::resolve_from_nx_json(&config.cwd);
+  let global_triggers: Vec<GlobalTrigger> = if let Some(ref inputs) = resolved_inputs {
+    named_inputs::check_global_invalidation(inputs, &changed_files)
+  } else {
+    Vec::new()
+  };
+
+  if !global_triggers.is_empty() && !generate_report {
+    let mut all_projects: Vec<String> = config.projects.iter().map(|p| p.name.clone()).collect();
+    all_projects.sort();
+    profiler.print_report();
+    return Ok(AffectedResult {
+      affected_projects: all_projects,
+      report: None,
+    });
+  }
+
   let changed_files = if let Some(ref inputs) = resolved_inputs {
-    // Check for global invalidation (e.g., babel.config.json, patches/*)
-    if let Some(trigger_file) = named_inputs::check_global_invalidation(inputs, &changed_files) {
-      let mut all_projects: Vec<String> = config.projects.iter().map(|p| p.name.clone()).collect();
-      all_projects.sort();
-      profiler.print_report();
-      let report = if generate_report {
-        Some(AffectedReport {
-          projects: all_projects
-            .iter()
-            .map(|name| AffectedProjectInfo {
-              name: name.clone(),
-              causes: vec![AffectCause::GlobalInvalidation {
-                file: trigger_file.clone(),
-              }],
-            })
-            .collect(),
-        })
-      } else {
-        None
-      };
-      return Ok(AffectedResult {
-        affected_projects: all_projects,
-        report,
-      });
-    }
-    // Filter out negated files (e.g., *.figma.tsx)
     named_inputs::filter_negated_files(inputs, changed_files, &config.projects)
   } else {
     changed_files
@@ -596,7 +600,21 @@ fn find_affected_internal(
     },
   );
 
-  // Step 8: Convert to sorted vector
+  // Step 8: Union semantic and global-invalidation results.
+  //
+  // Track the set of projects with semantic causes (used for ReportTotals)
+  // before unioning so we don't lose that distinction once global causes are
+  // mixed in. When global triggers fired, every workspace project is
+  // affected — matching Nx's behavior — but semantic causes are still
+  // recorded for the projects that have them.
+  let semantically_affected_names: FxHashSet<String> = affected_packages.iter().cloned().collect();
+
+  if !global_triggers.is_empty() {
+    for project in &config.projects {
+      affected_packages.insert(project.name.clone());
+    }
+  }
+
   let mut affected_projects: Vec<String> = affected_packages.into_iter().collect();
   affected_projects.sort();
 
@@ -604,6 +622,21 @@ fn find_affected_internal(
 
   // Step 9: Build report if requested
   let report = if generate_report {
+    if !global_triggers.is_empty() {
+      // Attach a GlobalInvalidation cause per trigger to every project so
+      // the report can render the per-project pill, and so the collapsed
+      // group is unambiguous about which file(s) caused the invalidation.
+      for project in &config.projects {
+        let entry = project_causes.entry(project.name.clone()).or_default();
+        for trigger in &global_triggers {
+          entry.push(AffectCause::GlobalInvalidation {
+            file: trigger.file.clone(),
+            named_input: trigger.named_input.clone(),
+          });
+        }
+      }
+    }
+
     let mut projects_info: Vec<AffectedProjectInfo> = project_causes
       .into_iter()
       .map(|(name, mut causes)| {
@@ -615,8 +648,28 @@ fn find_affected_internal(
       .collect();
     projects_info.sort_by(|a, b| a.name.cmp(&b.name));
 
+    let globally_invalidated_names: FxHashSet<String> = if global_triggers.is_empty() {
+      FxHashSet::default()
+    } else {
+      config.projects.iter().map(|p| p.name.clone()).collect()
+    };
+
+    let overlap = globally_invalidated_names
+      .intersection(&semantically_affected_names)
+      .count();
+    let totals = ReportTotals {
+      globally_invalidated: globally_invalidated_names.len().saturating_sub(overlap),
+      semantically_affected: semantically_affected_names.len(),
+      overlap,
+      changed_files: total_changed_files,
+    };
+
     Some(AffectedReport {
       projects: projects_info,
+      global_triggers,
+      totals,
+      version: env!("CARGO_PKG_VERSION"),
+      run_started_at_unix_secs,
     })
   } else {
     None

--- a/src/named_inputs.rs
+++ b/src/named_inputs.rs
@@ -1,17 +1,27 @@
-use crate::types::{ChangedFile, Project};
+use crate::types::{ChangedFile, GlobalTrigger, Project};
 use glob::Pattern;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tracing::{debug, warn};
+
+/// A compiled global-invalidation pattern that retains the name of the
+/// `namedInput` it originated from (e.g. `sharedGlobals`), so the report can
+/// surface a term the user wrote in their `nx.json`.
+#[derive(Debug, Clone)]
+pub struct GlobalPattern {
+  pub named_input: String,
+  pub raw_pattern: String,
+  pub pattern: Pattern,
+}
 
 /// Resolved named inputs configuration from nx.json
 #[derive(Debug, Default)]
 pub struct ResolvedNamedInputs {
   /// Glob patterns for workspace-root files that invalidate all projects
   /// e.g., "babel.config.json", "patches/*"
-  pub global_patterns: Vec<Pattern>,
+  pub global_patterns: Vec<GlobalPattern>,
   /// Pre-compiled negation glob patterns for project-root files to exclude
   /// e.g., "**/*.figma.tsx"
   pub negation_patterns: Vec<Pattern>,
@@ -40,10 +50,12 @@ pub fn resolve_from_nx_json(cwd: &Path) -> Option<ResolvedNamedInputs> {
     nx_json.named_inputs.len()
   );
 
-  // Resolve the "default" named input recursively
-  let mut resolved_patterns = Vec::new();
+  // Resolve the "default" named input recursively, tracking the named-input
+  // each pattern originated from so the report can show it back to the user.
+  let mut resolved_patterns: Vec<(String, String)> = Vec::new();
   let mut visited = std::collections::HashSet::new();
   resolve_named_input(
+    "default",
     "default",
     &nx_json.named_inputs,
     &mut resolved_patterns,
@@ -55,10 +67,10 @@ pub fn resolve_from_nx_json(cwd: &Path) -> Option<ResolvedNamedInputs> {
     return None;
   }
 
-  let mut global_patterns = Vec::new();
+  let mut global_patterns: Vec<GlobalPattern> = Vec::new();
   let mut negation_patterns = Vec::new();
 
-  for pattern_str in &resolved_patterns {
+  for (origin, pattern_str) in &resolved_patterns {
     if let Some(negated) = pattern_str.strip_prefix('!') {
       // Negation pattern
       if let Some(suffix) = negated.strip_prefix("{projectRoot}/") {
@@ -81,8 +93,12 @@ pub fn resolve_from_nx_json(cwd: &Path) -> Option<ResolvedNamedInputs> {
       // Global workspace-root pattern
       match Pattern::new(suffix) {
         Ok(pat) => {
-          debug!("Global pattern: {}", suffix);
-          global_patterns.push(pat);
+          debug!("Global pattern from '{}': {}", origin, suffix);
+          global_patterns.push(GlobalPattern {
+            named_input: origin.clone(),
+            raw_pattern: pattern_str.clone(),
+            pattern: pat,
+          });
         }
         Err(e) => {
           warn!("Invalid glob pattern '{}': {}", suffix, e);
@@ -110,10 +126,17 @@ pub fn resolve_from_nx_json(cwd: &Path) -> Option<ResolvedNamedInputs> {
 }
 
 /// Recursively resolve a named input, following references to other named inputs.
+///
+/// `origin` is the user-facing namedInput name attributed to literal patterns
+/// at this level (i.e. the most recent named input the user wrote in nx.json
+/// along this recursion path). When `default` references `sharedGlobals`, the
+/// recursive call passes `origin = "sharedGlobals"` so patterns surfaced from
+/// there carry the term the user recognizes.
 fn resolve_named_input(
   name: &str,
+  origin: &str,
   all_inputs: &HashMap<String, Vec<serde_json::Value>>,
-  resolved: &mut Vec<String>,
+  resolved: &mut Vec<(String, String)>,
   visited: &mut std::collections::HashSet<String>,
 ) {
   if !visited.insert(name.to_string()) {
@@ -134,10 +157,12 @@ fn resolve_named_input(
       serde_json::Value::String(s) => {
         if s.starts_with('{') || s.starts_with('!') {
           // It's a file pattern (e.g., "{projectRoot}/**/*" or "!{projectRoot}/**/*.spec.ts")
-          resolved.push(s.clone());
+          resolved.push((origin.to_string(), s.clone()));
         } else {
-          // It's a reference to another named input (e.g., "sharedGlobals")
-          resolve_named_input(s, all_inputs, resolved, visited);
+          // It's a reference to another named input (e.g., "sharedGlobals").
+          // The referenced name becomes the new origin so leaf patterns are
+          // attributed to it, not to the input that referenced it.
+          resolve_named_input(s, s, all_inputs, resolved, visited);
         }
       }
       serde_json::Value::Object(_) => {
@@ -154,12 +179,10 @@ fn resolve_named_input(
 
 impl ResolvedNamedInputs {
   /// Check if a changed file matches any global invalidation pattern.
-  /// `file_path` should be relative to workspace root.
-  pub fn matches_global_pattern(&self, file_path: &Path) -> bool {
-    let path_str = match file_path.to_str() {
-      Some(s) => s,
-      None => return false,
-    };
+  /// `file_path` should be relative to workspace root. Returns the matching
+  /// `GlobalPattern` so callers learn *which* namedInput triggered.
+  pub fn matches_global_pattern(&self, file_path: &Path) -> Option<&GlobalPattern> {
+    let path_str = file_path.to_str()?;
 
     let opts = glob::MatchOptions {
       case_sensitive: true,
@@ -167,17 +190,18 @@ impl ResolvedNamedInputs {
       require_literal_leading_dot: false,
     };
 
-    for pattern in &self.global_patterns {
-      if pattern.matches_with(path_str, opts) {
+    for gp in &self.global_patterns {
+      if gp.pattern.matches_with(path_str, opts) {
         debug!(
-          "File '{}' matches global pattern '{}'",
+          "File '{}' matches global pattern '{}' from namedInput '{}'",
           path_str,
-          pattern.as_str()
+          gp.pattern.as_str(),
+          gp.named_input
         );
-        return true;
+        return Some(gp);
       }
     }
-    false
+    None
   }
 
   /// Check if a changed file should be excluded by negation patterns.
@@ -230,22 +254,32 @@ impl ResolvedNamedInputs {
   }
 }
 
-/// Check if any changed file triggers global invalidation.
-/// Returns `Some(file_path)` of the triggering file, or `None`.
+/// Collect every changed file that triggers global invalidation along with the
+/// namedInput it matched. Returns an empty vec when no file matches.
+///
+/// Note: a previous version of this function returned only the first match,
+/// which was enough to short-circuit the affected-projects calculation but
+/// hid information from the report. The report now lists every trigger so
+/// users can see at a glance *why* a run was globally invalidated.
 pub fn check_global_invalidation(
   inputs: &ResolvedNamedInputs,
   changed_files: &[ChangedFile],
-) -> Option<PathBuf> {
+) -> Vec<GlobalTrigger> {
+  let mut triggers = Vec::new();
   for changed_file in changed_files {
-    if inputs.matches_global_pattern(&changed_file.file_path) {
+    if let Some(gp) = inputs.matches_global_pattern(&changed_file.file_path) {
       debug!(
-        "Global invalidation triggered by {:?}",
-        changed_file.file_path
+        "Global invalidation triggered by {:?} (namedInput: {})",
+        changed_file.file_path, gp.named_input
       );
-      return Some(changed_file.file_path.clone());
+      triggers.push(GlobalTrigger {
+        file: changed_file.file_path.clone(),
+        named_input: gp.named_input.clone(),
+        raw_pattern: gp.raw_pattern.clone(),
+      });
     }
   }
-  None
+  triggers
 }
 
 /// Filter out changed files that match negation patterns from namedInputs.
@@ -308,9 +342,20 @@ mod tests {
 
     let resolved = resolve_from_nx_json(root).unwrap();
     assert_eq!(resolved.global_patterns.len(), 2);
-    assert!(resolved.matches_global_pattern(&PathBuf::from("babel.config.json")));
-    assert!(resolved.matches_global_pattern(&PathBuf::from("patches/some-patch.patch")));
-    assert!(!resolved.matches_global_pattern(&PathBuf::from("src/index.ts")));
+    // Both global patterns should be attributed to the `sharedGlobals`
+    // namedInput, not to `default` (which only referenced it).
+    for gp in &resolved.global_patterns {
+      assert_eq!(gp.named_input, "sharedGlobals");
+    }
+    assert!(resolved
+      .matches_global_pattern(&PathBuf::from("babel.config.json"))
+      .is_some());
+    assert!(resolved
+      .matches_global_pattern(&PathBuf::from("patches/some-patch.patch"))
+      .is_some());
+    assert!(resolved
+      .matches_global_pattern(&PathBuf::from("src/index.ts"))
+      .is_none());
   }
 
   #[test]
@@ -364,8 +409,16 @@ mod tests {
 
     let resolved = resolve_from_nx_json(root).unwrap();
     assert_eq!(resolved.global_patterns.len(), 2);
-    assert!(resolved.matches_global_pattern(&PathBuf::from("babel.config.json")));
-    assert!(resolved.matches_global_pattern(&PathBuf::from("ci/utils.Jenkinsfile")));
+    let babel = resolved
+      .matches_global_pattern(&PathBuf::from("babel.config.json"))
+      .expect("babel.config.json should match");
+    assert_eq!(babel.named_input, "sharedGlobals");
+    let jenkins = resolved
+      .matches_global_pattern(&PathBuf::from("ci/utils.Jenkinsfile"))
+      .expect("ci/utils.Jenkinsfile should match");
+    // Even though the chain is default → sharedGlobals → ciInputs, the leaf
+    // pattern is attributed to its most specific origin (ciInputs).
+    assert_eq!(jenkins.named_input, "ciInputs");
   }
 
   #[test]
@@ -386,7 +439,9 @@ mod tests {
 
     let resolved = resolve_from_nx_json(root).unwrap();
     assert_eq!(resolved.global_patterns.len(), 1);
-    assert!(resolved.matches_global_pattern(&PathBuf::from("file.json")));
+    assert!(resolved
+      .matches_global_pattern(&PathBuf::from("file.json"))
+      .is_some());
   }
 
   #[test]
@@ -464,5 +519,93 @@ mod tests {
 
     assert!(resolved.is_negated_by_any_project(&PathBuf::from("libs/a/src/foo.spec.ts"), &roots));
     assert!(!resolved.is_negated_by_any_project(&PathBuf::from("libs/a/src/foo.ts"), &roots));
+  }
+
+  #[test]
+  fn test_check_global_invalidation_returns_all_matches() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+
+    write_nx_json(
+      root,
+      r#"{
+        "namedInputs": {
+          "default": ["{projectRoot}/**/*", "sharedGlobals", "ciInputs"],
+          "sharedGlobals": [
+            "{workspaceRoot}/nx.json",
+            "{workspaceRoot}/package.json"
+          ],
+          "ciInputs": ["{workspaceRoot}/.github/workflows/ci.yml"]
+        }
+      }"#,
+    );
+
+    let resolved = resolve_from_nx_json(root).unwrap();
+    let changed = vec![
+      ChangedFile {
+        file_path: PathBuf::from(".github/workflows/ci.yml"),
+        changed_lines: vec![],
+      },
+      ChangedFile {
+        file_path: PathBuf::from("nx.json"),
+        changed_lines: vec![],
+      },
+      ChangedFile {
+        file_path: PathBuf::from("package.json"),
+        changed_lines: vec![],
+      },
+      ChangedFile {
+        file_path: PathBuf::from("libs/foo/src/index.ts"),
+        changed_lines: vec![],
+      },
+    ];
+
+    let triggers = check_global_invalidation(&resolved, &changed);
+    assert_eq!(
+      triggers.len(),
+      3,
+      "all three workspace-root files should be reported as triggers"
+    );
+
+    let by_file: HashMap<_, _> = triggers
+      .iter()
+      .map(|t| (t.file.clone(), t.named_input.clone()))
+      .collect();
+    assert_eq!(
+      by_file.get(&PathBuf::from(".github/workflows/ci.yml")),
+      Some(&"ciInputs".to_string())
+    );
+    assert_eq!(
+      by_file.get(&PathBuf::from("nx.json")),
+      Some(&"sharedGlobals".to_string())
+    );
+    assert_eq!(
+      by_file.get(&PathBuf::from("package.json")),
+      Some(&"sharedGlobals".to_string())
+    );
+  }
+
+  #[test]
+  fn test_check_global_invalidation_empty_when_no_match() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+
+    write_nx_json(
+      root,
+      r#"{
+        "namedInputs": {
+          "default": ["{projectRoot}/**/*", "sharedGlobals"],
+          "sharedGlobals": ["{workspaceRoot}/nx.json"]
+        }
+      }"#,
+    );
+
+    let resolved = resolve_from_nx_json(root).unwrap();
+    let changed = vec![ChangedFile {
+      file_path: PathBuf::from("libs/foo/src/index.ts"),
+      changed_lines: vec![],
+    }];
+
+    assert!(check_global_invalidation(&resolved, &changed).is_empty());
   }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -1550,8 +1550,10 @@ fn generate_cytoscape_data(report: &AffectedReport) -> String {
 
     let node_id = sanitize_node_id(&project.name);
     nodes.push(format!(
-      r#"{{ data: {{ id: "{}", label: "{}", type: "{}" }} }}"#,
-      node_id, project.name, node_type
+      r#"{{ data: {{ id: {}, label: {}, type: {} }} }}"#,
+      js_str(&node_id),
+      js_str(&project.name),
+      js_str(node_type)
     ));
     node_ids.insert(node_id);
   }
@@ -1578,8 +1580,9 @@ fn generate_cytoscape_data(report: &AffectedReport) -> String {
 
       if implicit_count > 0 {
         edges.push(format!(
-          r#"{{ data: {{ source: "{}", target: "{}", label: "implicit", type: "implicit" }} }}"#,
-          source_id, target_id
+          r#"{{ data: {{ source: {}, target: {}, label: "implicit", type: "implicit" }} }}"#,
+          js_str(&source_id),
+          js_str(&target_id)
         ));
       } else if import_count > 0 {
         let label = if import_count == 1 {
@@ -1588,8 +1591,10 @@ fn generate_cytoscape_data(report: &AffectedReport) -> String {
           format!("{} imports", import_count)
         };
         edges.push(format!(
-          r#"{{ data: {{ source: "{}", target: "{}", label: "{}" }} }}"#,
-          source_id, target_id, label
+          r#"{{ data: {{ source: {}, target: {}, label: {} }} }}"#,
+          js_str(&source_id),
+          js_str(&target_id),
+          js_str(&label)
         ));
       }
     }
@@ -1662,18 +1667,37 @@ fn generate_global_banner_html(report: &AffectedReport) -> String {
 /// Embed the run's machine-readable summary so downstream consumers (CI
 /// dashboards, scrapers) don't have to parse the rendered HTML.
 fn generate_metadata_script(report: &AffectedReport) -> String {
-  // serde_json handles all string escaping for us — never hand-roll JSON into
-  // an HTML attribute, and never use raw user-provided strings without escaping
-  // `</script>` (the JSON shape here has no controlled-by-attacker strings, but
-  // the safe default is to use serde_json::to_string which won't emit unescaped
-  // `<` either since these values are paths and identifiers).
+  // serde_json handles quote/backslash/control-char escaping, but it leaves
+  // `<` and `/` untouched — so a project name containing `</script>` would
+  // close this block early. escape_script_close neutralizes that sequence
+  // while keeping the payload valid JSON for JSON.parse consumers.
   match serde_json::to_string(report) {
     Ok(json) => format!(
       r#"<script type="application/json" id="domino-meta">{}</script>"#,
-      json
+      escape_script_close(&json)
     ),
     Err(_) => String::new(),
   }
+}
+
+/// Produce a JS/JSON string literal (including surrounding quotes) safe to
+/// drop into an inline `<script>`. `serde_json` handles quote, backslash,
+/// and control-character escaping; we additionally neutralize the `</`
+/// sequence (serde_json leaves `<` and `/` unescaped) so a project name like
+/// `</script><img onerror=…>` can't break out of the script element. The
+/// `\/` escape is valid in both JSON and JS, so consumers still parse it as
+/// a plain `/`.
+fn js_str(s: &str) -> String {
+  serde_json::to_string(s)
+    .unwrap_or_else(|_| "\"\"".to_string())
+    .replace("</", "<\\/")
+}
+
+/// Neutralize the `</` sequence in a serialized JSON blob so it can't close
+/// an enclosing `<script>` element. `\/` is a valid JSON escape, so
+/// `JSON.parse` on the consumer side is unaffected.
+fn escape_script_close(json: &str) -> String {
+  json.replace("</", "<\\/")
 }
 
 fn html_escape(s: &str) -> String {
@@ -2250,6 +2274,51 @@ mod tests {
     assert!(
       !html.contains(r#"href="data:image/svg+xml,<svg"#),
       "favicon data URI must url-encode `<`, otherwise some browsers/validators reject it"
+    );
+  }
+
+  #[test]
+  fn inline_scripts_escape_unsafe_project_names() {
+    // Project names flow into two inline-script contexts — the cytoscape
+    // `graphData` literal and the JSON metadata block. A name containing
+    // `</script>` or a quote must not break out of either, otherwise a
+    // maliciously-named project (e.g. introduced on a CI branch) becomes
+    // stored XSS when a reviewer opens the report. Identified by cubic.
+    let report = AffectedReport {
+      projects: vec![make_project(
+        r#"evil"</script><img src=x onerror=alert(1)>"#,
+        vec![AffectCause::DirectChange {
+          file: PathBuf::from("libs/evil/src/a.ts"),
+          symbol: None,
+          line: 1,
+        }],
+      )],
+      global_triggers: Vec::new(),
+      totals: empty_totals(),
+      version: env!("CARGO_PKG_VERSION"),
+      run_started_at_unix_secs: 0,
+    };
+
+    let graph = generate_cytoscape_data(&report);
+    // The raw closing-script sequence must never survive into the literal.
+    assert!(
+      !graph.contains("</script"),
+      "graph data leaked a raw </script: {}",
+      graph
+    );
+    // The embedded double-quote must be backslash-escaped, not raw, or it
+    // would terminate the JS string and corrupt the object literal.
+    assert!(
+      !graph.contains(r#"evil""#),
+      "unescaped quote in graph: {}",
+      graph
+    );
+
+    // Full document: neither inline-script context may contain the breakout.
+    let html = generate_html(&report);
+    assert!(
+      !html.contains("</script><img"),
+      "script breakout survived into rendered HTML"
     );
   }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::types::{AffectCause, AffectedReport};
+use crate::types::{AffectCause, AffectedProjectInfo, AffectedReport};
 use std::fs;
 use std::path::Path;
 
@@ -28,11 +28,21 @@ fn format_number(n: usize) -> String {
 fn generate_html(report: &AffectedReport) -> String {
   let graph_data = generate_cytoscape_data(report);
   let details_html = generate_details_html(report);
+  let banner_html = generate_global_banner_html(report);
+  let metadata_script = generate_metadata_script(report);
   let total_causes = report
     .projects
     .iter()
     .map(|p| p.causes.len())
     .sum::<usize>();
+  // Render the global/semantic split when global invalidation happened so
+  // the user can tell what came from `nx affected`-style global rules vs.
+  // real semantic signal. Hidden by `display: none` otherwise.
+  let summary_split_style = if report.global_triggers.is_empty() {
+    "display: none;"
+  } else {
+    ""
+  };
 
   format!(
     r#"<!DOCTYPE html>
@@ -697,6 +707,97 @@ fn generate_html(report: &AffectedReport) -> String {
             background: #f59e0b;
         }}
 
+        /* Distinct pill for Nx namedInputs global invalidation. Deliberately
+           a neutral slate so the user reads it as "infrastructure rule fired"
+           rather than "real direct code change" (which uses .direct/green). */
+        .cause-type.global {{
+            background: #64748b;
+        }}
+
+        .global-banner {{
+            background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
+            border: 1px solid #475569;
+            border-left: 4px solid #64748b;
+            border-radius: 8px;
+            padding: 1.25rem 1.5rem;
+            margin-bottom: 1.5rem;
+            color: #e2e8f0;
+        }}
+
+        .global-banner h3 {{
+            margin: 0 0 0.5rem 0;
+            color: #f1f5f9;
+            font-size: 1.1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }}
+
+        .global-banner p {{
+            margin: 0.5rem 0;
+            color: #cbd5e1;
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }}
+
+        .global-banner ul {{
+            margin: 0.75rem 0 0.5rem 0;
+            padding-left: 1.5rem;
+            color: #e2e8f0;
+        }}
+
+        .global-banner ul li {{
+            margin: 0.25rem 0;
+            font-size: 0.9rem;
+        }}
+
+        .global-banner .docs-link {{
+            color: #93c5fd;
+            text-decoration: none;
+            border-bottom: 1px dotted #93c5fd;
+        }}
+
+        .global-banner .docs-link:hover {{
+            color: #bfdbfe;
+        }}
+
+        .global-only-group {{
+            margin-top: 2rem;
+            background: #1a1a1a;
+            border: 1px solid #2a2a2a;
+            border-left: 4px solid #64748b;
+            border-radius: 8px;
+            padding: 1rem 1.25rem;
+        }}
+
+        .global-only-group > summary {{
+            cursor: pointer;
+            list-style: none;
+            color: #cbd5e1;
+            font-weight: 600;
+            font-size: 1rem;
+            user-select: none;
+        }}
+
+        .global-only-group > summary::-webkit-details-marker {{
+            display: none;
+        }}
+
+        .global-only-group > summary::before {{
+            content: '▸';
+            display: inline-block;
+            margin-right: 0.5rem;
+            transition: transform 0.15s ease;
+        }}
+
+        .global-only-group[open] > summary::before {{
+            transform: rotate(90deg);
+        }}
+
+        .global-only-group .global-only-inner {{
+            margin-top: 1rem;
+        }}
+
         .cause-details {{
             color: #aaa;
             font-size: 0.9rem;
@@ -731,11 +832,14 @@ fn generate_html(report: &AffectedReport) -> String {
     </style>
 </head>
 <body>
+    {}
     <div class="container">
         <header>
             <h1>🎯 True Affected Report</h1>
             <p class="subtitle">Dependency Graph & Impact Analysis</p>
         </header>
+
+        {}
 
         <div class="summary">
             <div class="summary-grid">
@@ -746,6 +850,18 @@ fn generate_html(report: &AffectedReport) -> String {
                 <div class="summary-item">
                     <div class="summary-value">{}</div>
                     <div class="summary-label">Total Causes</div>
+                </div>
+                <div class="summary-item" style="{}">
+                    <div class="summary-value">{}</div>
+                    <div class="summary-label">Globally Invalidated</div>
+                </div>
+                <div class="summary-item" style="{}">
+                    <div class="summary-value">{}</div>
+                    <div class="summary-label">Semantically Affected</div>
+                </div>
+                <div class="summary-item">
+                    <div class="summary-value">{}</div>
+                    <div class="summary-label">Changed Files</div>
                 </div>
             </div>
         </div>
@@ -805,15 +921,23 @@ fn generate_html(report: &AffectedReport) -> String {
         </div>
 
         <footer>
-            Generated by <strong>domino</strong> - True Affected Analysis
+            Generated by <strong>domino</strong> v{} &middot; True Affected Analysis
         </footer>
     </div>
 </body>
 </html>"#,
     graph_data,
+    metadata_script,
+    banner_html,
     format_number(report.projects.len()),
     format_number(total_causes),
-    details_html
+    summary_split_style,
+    format_number(report.totals.globally_invalidated),
+    summary_split_style,
+    format_number(report.totals.semantically_affected),
+    format_number(report.totals.changed_files),
+    details_html,
+    env!("CARGO_PKG_VERSION"),
   )
 }
 
@@ -925,10 +1049,123 @@ fn generate_cytoscape_data(report: &AffectedReport) -> String {
   )
 }
 
+/// Render the "Global invalidation detected" banner that explains *why* a
+/// whole-workspace affected list isn't a Domino misbehavior. Returns an
+/// empty string for non-global runs so the template stays compact.
+fn generate_global_banner_html(report: &AffectedReport) -> String {
+  if report.global_triggers.is_empty() {
+    return String::new();
+  }
+
+  let project_count = report.projects.len();
+  let trigger_count = report.global_triggers.len();
+
+  let mut items = String::new();
+  for trigger in &report.global_triggers {
+    items.push_str(&format!(
+      "<li><code>{}</code> &nbsp;&larr;&nbsp; matched <code>{}</code></li>",
+      html_escape(&trigger.file.display().to_string()),
+      html_escape(&trigger.named_input),
+    ));
+  }
+
+  format!(
+    r#"<div class="global-banner" role="status">
+            <h3>⚠️ Global invalidation detected</h3>
+            <p>
+                <strong>{trigger_count}</strong> changed file{trigger_plural} matched Nx <code>namedInputs</code>
+                workspace-root pattern{trigger_plural}, so all <strong>{project_count}</strong> projects
+                are marked affected &mdash; the same as <code>nx affected</code> would do.
+            </p>
+            <ul>{items}</ul>
+            <p>
+                Semantic analysis of the other changed files still ran &mdash; the
+                <em>Detailed Impact Analysis</em> section below separates projects affected by
+                real code signal from those only swept up by the global rule.
+                See the
+                <a class="docs-link" href="https://nx.dev/concepts/more-concepts/customizing-inputs" target="_blank" rel="noopener">
+                    Nx <code>namedInputs</code> docs
+                </a>
+                for the underlying mechanic.
+            </p>
+        </div>"#,
+    trigger_count = trigger_count,
+    trigger_plural = if trigger_count == 1 { "" } else { "s" },
+    project_count = format_number(project_count),
+    items = items,
+  )
+}
+
+/// Embed the run's machine-readable summary so downstream consumers (CI
+/// dashboards, scrapers) don't have to parse the rendered HTML.
+fn generate_metadata_script(report: &AffectedReport) -> String {
+  // serde_json handles all string escaping for us — never hand-roll JSON into
+  // an HTML attribute, and never use raw user-provided strings without escaping
+  // `</script>` (the JSON shape here has no controlled-by-attacker strings, but
+  // the safe default is to use serde_json::to_string which won't emit unescaped
+  // `<` either since these values are paths and identifiers).
+  match serde_json::to_string(report) {
+    Ok(json) => format!(
+      r#"<script type="application/json" id="domino-meta">{}</script>"#,
+      json
+    ),
+    Err(_) => String::new(),
+  }
+}
+
+fn html_escape(s: &str) -> String {
+  s.replace('&', "&amp;")
+    .replace('<', "&lt;")
+    .replace('>', "&gt;")
+    .replace('"', "&quot;")
+    .replace('\'', "&#39;")
+}
+
+/// Build the suffix shown in the collapsed group's summary line. When every
+/// globally-invalidated project was hit by patterns from a single namedInput,
+/// surface that name (e.g. " via `sharedGlobals`"). Otherwise stay generic.
+fn global_only_group_label(global_only: &[&AffectedProjectInfo]) -> String {
+  use std::collections::HashSet;
+  let mut inputs: HashSet<&str> = HashSet::new();
+  for project in global_only {
+    for cause in &project.causes {
+      if let AffectCause::GlobalInvalidation { named_input, .. } = cause {
+        inputs.insert(named_input.as_str());
+      }
+    }
+  }
+  match inputs.len() {
+    1 => {
+      let name = inputs.into_iter().next().unwrap_or("");
+      format!(" via <code>{}</code>", html_escape(name))
+    }
+    _ => " via Nx <code>namedInputs</code>".to_string(),
+  }
+}
+
+/// Returns true when this project's only signal is global invalidation.
+/// Used to collapse the long tail at the bottom of the report so semantic
+/// signal isn't drowned out.
+fn is_globally_invalidated_only(project: &AffectedProjectInfo) -> bool {
+  !project.causes.is_empty()
+    && project
+      .causes
+      .iter()
+      .all(|c| matches!(c, AffectCause::GlobalInvalidation { .. }))
+}
+
 fn generate_details_html(report: &AffectedReport) -> String {
   let mut html = String::new();
 
-  for project in &report.projects {
+  // Partition projects so semantic signal (DirectChange, ImportedSymbol, etc.)
+  // floats to the top expanded, and the global-only long tail is collapsed
+  // into a single summary row at the bottom.
+  let (global_only, semantic): (Vec<_>, Vec<_>) = report
+    .projects
+    .iter()
+    .partition(|p| is_globally_invalidated_only(p));
+
+  for project in &semantic {
     // Determine affect type
     let mut has_direct = false;
     let mut has_imported = false;
@@ -1090,12 +1327,13 @@ fn generate_details_html(report: &AffectedReport) -> String {
           ));
           html.push_str("</div>");
         }
-        AffectCause::GlobalInvalidation { file } => {
-          html.push_str("<span class=\"cause-type direct\">Global Invalidation</span>");
+        AffectCause::GlobalInvalidation { file, named_input } => {
+          html.push_str("<span class=\"cause-type global\">Global Invalidation</span>");
           html.push_str("<div class=\"cause-details\">");
           html.push_str(&format!(
-            "Triggered by: <span class=\"code-path\">{}</span>",
-            file.display()
+            "Triggered by: <span class=\"code-path\">{}</span> &nbsp;&larr;&nbsp; matched <code>{}</code>",
+            html_escape(&file.display().to_string()),
+            html_escape(named_input),
           ));
           html.push_str("</div>");
         }
@@ -1107,9 +1345,306 @@ fn generate_details_html(report: &AffectedReport) -> String {
     html.push_str("</ul></div></details></div>");
   }
 
+  // Collapsed group for projects that are only on the affected list because
+  // of global invalidation. Hidden by default to keep semantic signal visible.
+  if !global_only.is_empty() {
+    let group_label = global_only_group_label(&global_only);
+    html.push_str(&format!(
+      r#"<details class="global-only-group">
+                <summary>{count} projects globally invalidated{label} &mdash; click to expand</summary>
+                <div class="global-only-inner">"#,
+      count = format_number(global_only.len()),
+      label = group_label,
+    ));
+
+    for project in &global_only {
+      html.push_str(&format!(
+        r#"<div class="project-card" data-filter-type="affected">
+                    <details>
+                        <summary>
+                            <div class="project-name">📦 {name}</div>
+                            <div class="badge-container">
+                                <span class="affect-badge badge-affected">Global Only</span>
+                                <span class="affect-badge" style="background: #555;">
+                                    {count} cause{plural}
+                                </span>
+                            </div>
+                        </summary>
+                        <div class="cause-list-container">
+                            <ul class="cause-list">"#,
+        name = html_escape(&project.name),
+        count = project.causes.len(),
+        plural = if project.causes.len() == 1 { "" } else { "s" },
+      ));
+
+      for cause in &project.causes {
+        if let AffectCause::GlobalInvalidation { file, named_input } = cause {
+          html.push_str(&format!(
+            r#"<li class="cause-item">
+                                <span class="cause-type global">Global Invalidation</span>
+                                <div class="cause-details">
+                                    Triggered by: <span class="code-path">{}</span> &nbsp;&larr;&nbsp; matched <code>{}</code>
+                                </div>
+                            </li>"#,
+            html_escape(&file.display().to_string()),
+            html_escape(named_input),
+          ));
+        }
+      }
+
+      html.push_str("</ul></div></details></div>");
+    }
+
+    html.push_str("</div></details>");
+  }
+
   html
 }
 
 fn sanitize_node_id(name: &str) -> String {
   name.replace('-', "_").replace('@', "").replace('/', "_")
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::types::{AffectedProjectInfo, GlobalTrigger, ReportTotals};
+  use std::path::PathBuf;
+
+  fn make_project(name: &str, causes: Vec<AffectCause>) -> AffectedProjectInfo {
+    AffectedProjectInfo {
+      name: name.to_string(),
+      causes,
+    }
+  }
+
+  fn empty_totals() -> ReportTotals {
+    ReportTotals::default()
+  }
+
+  fn synth_global_report() -> AffectedReport {
+    // Mimics the real-world incident: ~600 projects swept up by a workflow
+    // file change, ~15 with semantic signal, 3 global trigger files.
+    let mut projects = Vec::new();
+    for i in 0..600 {
+      projects.push(make_project(
+        &format!("lib-{:03}", i),
+        vec![
+          AffectCause::GlobalInvalidation {
+            file: PathBuf::from(".github/workflows/ci.yml"),
+            named_input: "sharedGlobals".to_string(),
+          },
+          AffectCause::GlobalInvalidation {
+            file: PathBuf::from("nx.json"),
+            named_input: "sharedGlobals".to_string(),
+          },
+          AffectCause::GlobalInvalidation {
+            file: PathBuf::from("package.json"),
+            named_input: "ciInputs".to_string(),
+          },
+        ],
+      ));
+    }
+    for i in 0..15 {
+      projects.push(make_project(
+        &format!("app-{}", i),
+        vec![
+          AffectCause::DirectChange {
+            file: PathBuf::from(format!("apps/app-{}/src/index.ts", i)),
+            symbol: Some(format!("handleClick{}", i)),
+            line: 42 + i,
+          },
+          AffectCause::ImportedSymbol {
+            source_project: "shared-utils".to_string(),
+            symbol: "formatDate".to_string(),
+            via_file: PathBuf::from(format!("apps/app-{}/src/index.ts", i)),
+            source_file: PathBuf::from("libs/shared-utils/src/format.ts"),
+          },
+          AffectCause::GlobalInvalidation {
+            file: PathBuf::from(".github/workflows/ci.yml"),
+            named_input: "sharedGlobals".to_string(),
+          },
+        ],
+      ));
+    }
+    projects.sort_by(|a, b| a.name.cmp(&b.name));
+
+    AffectedReport {
+      projects,
+      global_triggers: vec![
+        GlobalTrigger {
+          file: PathBuf::from(".github/workflows/ci.yml"),
+          named_input: "sharedGlobals".to_string(),
+          raw_pattern: "{workspaceRoot}/.github/workflows/ci.yml".to_string(),
+        },
+        GlobalTrigger {
+          file: PathBuf::from("nx.json"),
+          named_input: "sharedGlobals".to_string(),
+          raw_pattern: "{workspaceRoot}/nx.json".to_string(),
+        },
+        GlobalTrigger {
+          file: PathBuf::from("package.json"),
+          named_input: "ciInputs".to_string(),
+          raw_pattern: "{workspaceRoot}/package.json".to_string(),
+        },
+      ],
+      totals: ReportTotals {
+        globally_invalidated: 600,
+        semantically_affected: 15,
+        overlap: 15,
+        changed_files: 4,
+      },
+      version: env!("CARGO_PKG_VERSION"),
+      run_started_at_unix_secs: 1_716_595_200,
+    }
+  }
+
+  fn synth_normal_report() -> AffectedReport {
+    let projects = vec![
+      make_project(
+        "app-web",
+        vec![AffectCause::DirectChange {
+          file: PathBuf::from("apps/web/src/main.ts"),
+          symbol: Some("bootstrap".to_string()),
+          line: 12,
+        }],
+      ),
+      make_project(
+        "shared-utils",
+        vec![AffectCause::ImportedSymbol {
+          source_project: "core".to_string(),
+          symbol: "Logger".to_string(),
+          via_file: PathBuf::from("libs/shared-utils/src/log.ts"),
+          source_file: PathBuf::from("libs/core/src/logger.ts"),
+        }],
+      ),
+      make_project(
+        "ui-widgets",
+        vec![AffectCause::ImplicitDependency {
+          depends_on: "shared-utils".to_string(),
+        }],
+      ),
+    ];
+    AffectedReport {
+      projects,
+      global_triggers: Vec::new(),
+      totals: ReportTotals {
+        globally_invalidated: 0,
+        semantically_affected: 3,
+        overlap: 0,
+        changed_files: 2,
+      },
+      version: env!("CARGO_PKG_VERSION"),
+      run_started_at_unix_secs: 1_716_595_200,
+    }
+  }
+
+  #[test]
+  fn banner_renders_only_when_global_triggers_present() {
+    let global = generate_html(&synth_global_report());
+    let normal = generate_html(&synth_normal_report());
+
+    assert!(global.contains("Global invalidation detected"));
+    assert!(global.contains("cause-type global"));
+    assert!(global.contains(r#"<div class="global-banner""#));
+    assert!(global.contains(r#"id="domino-meta""#));
+
+    // Non-global runs MUST remain visually identical to today's report —
+    // no banner element, no new pill, no collapsed group element. (The CSS
+    // *classes* are still emitted in the always-included <style> block; we
+    // assert on the rendered elements, not the stylesheet.)
+    assert!(!normal.contains("Global invalidation detected"));
+    assert!(!normal.contains("\"cause-type global\""));
+    assert!(!normal.contains(r#"<div class="global-banner""#));
+    assert!(!normal.contains(r#"<details class="global-only-group""#));
+    // The metadata script is harmless on non-global runs and lets dashboards
+    // pick up the same shape regardless of run type.
+    assert!(normal.contains(r#"id="domino-meta""#));
+  }
+
+  #[test]
+  fn json_metadata_contains_camelcase_fields() {
+    let html = generate_html(&synth_global_report());
+    // Spot-check the camelCase shape so downstream consumers can rely on it.
+    assert!(html.contains("\"globalTriggers\""));
+    assert!(html.contains("\"namedInput\":\"sharedGlobals\""));
+    assert!(html.contains("\"rawPattern\""));
+    assert!(html.contains("\"runStartedAtUnixSecs\""));
+    assert!(html.contains("\"globallyInvalidated\":600"));
+  }
+
+  #[test]
+  fn global_only_projects_are_collapsed_at_bottom() {
+    let html = generate_html(&synth_global_report());
+    let semantic_start = html
+      .find(r#"data-filter-type="both""#)
+      .expect("expected a semantic project card with `both` filter type");
+    let group_start = html
+      .find(r#"<details class="global-only-group""#)
+      .expect("expected the collapsed global-only group element");
+    assert!(
+      semantic_start < group_start,
+      "semantic project cards must appear before the collapsed global-only group \
+       (semantic at {}, group at {})",
+      semantic_start,
+      group_start
+    );
+  }
+
+  #[test]
+  fn pill_does_not_use_direct_class_for_global_cause() {
+    // Regression guard for the original UX bug: the global cause was
+    // sharing the green `.direct` pill, conflating it with real code edits.
+    let html = generate_html(&synth_global_report());
+    let first_global = html
+      .find("Global Invalidation")
+      .expect("global pill present");
+    let nearby = &html[first_global.saturating_sub(80)..first_global];
+    assert!(
+      nearby.contains("cause-type global"),
+      "expected `cause-type global` near the pill, got: {}",
+      nearby
+    );
+  }
+
+  // --- Sample report harness ---------------------------------------------
+  //
+  // These tests are #[ignore]d so they don't run in normal CI. Invoke with:
+  //   cargo test --lib sample_report -- --ignored --nocapture
+  // to write two HTML files you can open in a browser to sanity-check the UI.
+
+  #[test]
+  #[ignore]
+  fn sample_report_global() {
+    let html = generate_html(&synth_global_report());
+    std::fs::write("/tmp/domino-report-global.html", &html).unwrap();
+    println!(
+      "wrote /tmp/domino-report-global.html ({} bytes)",
+      html.len()
+    );
+  }
+
+  #[test]
+  #[ignore]
+  fn sample_report_normal() {
+    let html = generate_html(&synth_normal_report());
+    std::fs::write("/tmp/domino-report-normal.html", &html).unwrap();
+    println!(
+      "wrote /tmp/domino-report-normal.html ({} bytes)",
+      html.len()
+    );
+  }
+
+  #[test]
+  fn empty_report_does_not_panic() {
+    // Defensive: AffectedReport with no projects shouldn't blow up.
+    let report = AffectedReport {
+      projects: Vec::new(),
+      global_triggers: Vec::new(),
+      totals: empty_totals(),
+      version: env!("CARGO_PKG_VERSION"),
+      run_started_at_unix_secs: 0,
+    };
+    let _ = generate_html(&report);
+  }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -3,6 +3,71 @@ use crate::types::{AffectCause, AffectedProjectInfo, AffectedReport};
 use std::fs;
 use std::path::Path;
 
+/// Canonical project URL — surfaced in the top bar and footer so anyone with
+/// the HTML in hand can get back to the source.
+const REPO_URL: &str = "https://github.com/frontops-dev/domino";
+
+/// Body of `docs/assets/logo.svg`, inlined so the report stays a single
+/// self-contained HTML file. Keep in sync with the docs asset when the brand
+/// mark changes — the file path is recorded here intentionally.
+/// Source: docs/assets/logo.svg
+const LOGO_SVG: &str = r##"<svg id="domino-logo" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="domino logo" role="img"><path d="M78.3812 11.882C80.5232 4.5195 88.7579 -0.0415959 97.0989 2.93669L97.0999 2.93571L163.14 26.006L163.158 26.0119L163.176 26.0197C170.731 28.9903 174.235 37.4172 171.465 45.1545L122.279 188.194L122.28 188.195C119.857 195.504 112.473 200.07 104.54 197.667L104.518 197.66L104.496 197.653L36.1673 173.477L35.8372 173.36C28.9454 170.819 25.3949 163.324 27.7728 156.328L27.7767 156.32L78.3812 11.882Z" fill="url(#dlg0)" stroke="#959494" stroke-width="2"/><path d="M159.31 30.85L95.42 8.99001C90.43 7.23001 86.28 10.01 85.04 14.72L62 80.5L142 109L164.43 43.78C166.26 38.51 164.71 33.03 159.31 30.85Z" fill="#F26F0D"/><path d="M60.09 86.8L35.28 157.08C33.99 161.16 36.06 165.39 39.91 166.72L106.06 190.71C110.71 192.18 114.41 188.84 116.07 183.96L139.84 114.61L60.09 86.8Z" fill="url(#dlg1)"/><path d="M126.42 36.26L95.19 76.71L102.72 79.38L133.88 38.62L126.42 36.26Z" fill="#FEFFFE"/><path d="M119.96 118.27C115.28 118.06 112.96 121.67 113.27 126.09L91.72 135.79C89.92 133.81 87.21 132.87 85.46 133.73L74.61 111.84C77.92 108.87 76.98 102.28 71.32 100.24C65.43 98.97 62.48 104.62 63.41 108.77C64.42 112.98 68.12 114.58 71.36 113.59L82.68 134.92C80.84 136.42 80.04 138.33 80.13 140.83L57.82 150.37C55.84 147.62 51.01 146.74 47.81 149.55C44.12 153.19 45.63 158.89 49.99 160.93C54.92 162.66 59.52 158.82 59.16 154.12L81.02 144.28C82.89 147.09 86.04 147.25 88.08 146.34L99.18 167.46C95.06 170.99 96.05 176.15 100.41 178.75C105.44 180.87 109.71 176.96 110.12 173.22C110.31 168.88 106.48 165.69 102.04 166.06L91.22 144.73C93.05 143.48 93.62 140.84 93.19 138.6L114.21 129.41C116.82 133.01 122.61 132.78 125.22 129.6C128.48 125.77 126.41 119.19 119.96 118.27Z" fill="#B9E8F2"/><defs><linearGradient id="dlg0" x1="54.1908" y1="17.4036" x2="133.037" y2="181.855" gradientUnits="userSpaceOnUse"><stop stop-color="#505050"/><stop offset="1" stop-color="#272727"/></linearGradient><linearGradient id="dlg1" x1="67.6978" y1="91.8004" x2="107.257" y2="187.974" gradientUnits="userSpaceOnUse"><stop stop-color="#1C74AE"/><stop offset="1" stop-color="#125A8E"/></linearGradient></defs></svg>"##;
+
+/// Lucide-style stroke icons. All use `stroke="currentColor"` so they recolor
+/// via CSS. 16×16 viewport. Kept inline for the single-file constraint.
+const ICON_GITHUB: &str = r##"<svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>"##;
+const ICON_EXTERNAL: &str = r##"<svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 10L13 3M13 3H8M13 3v5M11 8.5v3a1.5 1.5 0 0 1-1.5 1.5h-6A1.5 1.5 0 0 1 2 11.5v-6A1.5 1.5 0 0 1 3.5 4h3"/></svg>"##;
+const ICON_INFO: &str = r##"<svg viewBox="0 0 16 16" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="8" cy="8" r="6.5"/><path d="M8 7.5v3.5M8 5.25v.5"/></svg>"##;
+const ICON_PACKAGE: &str = r##"<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 4.5L8 1.5 2 4.5v7L8 14.5l6-3v-7Z"/><path d="M2 4.5L8 7.5l6-3M8 7.5V14.5"/></svg>"##;
+
+/// Minimal URL-encoder for inlining an SVG into a `data:image/svg+xml,...`
+/// attribute value. Encodes only the characters that *must* be escaped:
+/// `%` (encoding sentinel), `#` (URL fragment), `<`/`>`/`"` (HTML attribute
+/// boundary safety). Lets us embed the domino logo as a favicon without
+/// adding a base64 dependency or shipping the SVG as a separate file.
+fn url_encode_svg(svg: &str) -> String {
+  let mut out = String::with_capacity(svg.len() + 32);
+  for c in svg.chars() {
+    match c {
+      '%' => out.push_str("%25"),
+      '#' => out.push_str("%23"),
+      '<' => out.push_str("%3C"),
+      '>' => out.push_str("%3E"),
+      '"' => out.push_str("%22"),
+      _ => out.push(c),
+    }
+  }
+  out
+}
+
+/// Human-readable relative time used in the hero eyebrow. Dep-free: keeps
+/// the report from pulling chrono/time just to render "12 minutes ago".
+/// Falls back to an absolute date for runs older than 7 days.
+fn format_relative_time(unix_secs: i64) -> String {
+  use std::time::{SystemTime, UNIX_EPOCH};
+  let now = SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .map(|d| d.as_secs() as i64)
+    .unwrap_or(0);
+  let delta = now.saturating_sub(unix_secs);
+  match delta {
+    d if d < 0 => "just now".to_string(),
+    d if d < 45 => "just now".to_string(),
+    d if d < 90 => "a minute ago".to_string(),
+    d if d < 60 * 45 => format!("{} minutes ago", d / 60),
+    d if d < 60 * 90 => "an hour ago".to_string(),
+    d if d < 60 * 60 * 22 => format!("{} hours ago", d / 3600),
+    d if d < 60 * 60 * 36 => "yesterday".to_string(),
+    d if d < 60 * 60 * 24 * 7 => format!("{} days ago", d / 86400),
+    _ => {
+      // >7 days: surface the absolute Unix time so the value is at least
+      // self-consistent. Browsers can format this via the embedded JSON
+      // metadata if a human-readable date is needed.
+      format!("{} (run timestamp)", unix_secs)
+    }
+  }
+}
+
 /// Generate an interactive HTML report with a dependency graph
 pub fn generate_html_report(report: &AffectedReport, output_path: &Path) -> Result<String> {
   let html = generate_html(report);
@@ -50,7 +115,11 @@ fn generate_html(report: &AffectedReport) -> String {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>True Affected - Dependency Report</title>
+    <title>domino · Affected Projects Report</title>
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,{favicon}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
     <script defer src="https://unpkg.com/cytoscape@3.28.1/dist/cytoscape.min.js"></script>
     <script defer src="https://unpkg.com/dagre@0.8.5/dist/dagre.min.js"></script>
     <script defer src="https://unpkg.com/cytoscape-dagre@2.5.0/cytoscape-dagre.js"></script>
@@ -61,7 +130,7 @@ fn generate_html(report: &AffectedReport) -> String {
     <script defer src="https://unpkg.com/cytoscape-cola@2.5.1/cytoscape-cola.js"></script>
     <script defer src="https://unpkg.com/cytoscape-cose-bilkent@4.1.0/cytoscape-cose-bilkent.js"></script>
     <script>
-        const graphData = {};
+        const graphData = {graph};
         let cy; // Make cy global for layout switching
 
         // Wait for all libraries to load
@@ -92,16 +161,17 @@ fn generate_html(report: &AffectedReport) -> String {
                     {{
                         selector: 'node',
                         style: {{
-                            'background-color': '#667eea',
+                            'background-color': '#21262d',
                             'label': 'data(label)',
-                            'color': '#fff',
+                            'color': '#e6edf3',
                             'text-valign': 'center',
                             'text-halign': 'center',
                             'font-size': '12px',
-                            'font-weight': '600',
+                            'font-weight': '500',
+                            'font-family': "'IBM Plex Sans', system-ui, sans-serif",
                             'width': 'label',
                             'height': 'label',
-                            'padding': '16px',
+                            'padding': '14px',
                             'shape': 'roundrectangle',
                             'text-wrap': 'wrap',
                             'text-max-width': '180px'
@@ -110,32 +180,34 @@ fn generate_html(report: &AffectedReport) -> String {
                     {{
                         selector: 'node[type="direct"]',
                         style: {{
-                            'background-color': '#10b981',
+                            'background-color': '#F26F0D',
                             'border-width': '3px',
-                            'border-color': '#059669'
+                            'border-color': '#c25608'
                         }}
                     }},
                     {{
                         selector: 'node[type="affected"]',
                         style: {{
-                            'background-color': '#3b82f6',
+                            'background-color': '#79c0ff',
                             'border-width': '2px',
-                            'border-color': '#2563eb'
+                            'border-color': '#388bfd',
+                            'color': '#0d1117'
                         }}
                     }},
                     {{
                         selector: 'edge',
                         style: {{
-                            'width': 2,
-                            'line-color': '#667eea',
-                            'target-arrow-color': '#667eea',
+                            'width': 1.5,
+                            'line-color': '#30363d',
+                            'target-arrow-color': '#30363d',
                             'target-arrow-shape': 'triangle',
                             'curve-style': 'bezier',
                             'label': 'data(label)',
                             'font-size': '10px',
-                            'color': '#aaa',
-                            'text-background-color': '#1a1a1a',
-                            'text-background-opacity': 0.8,
+                            'color': '#8b949e',
+                            'font-family': "'IBM Plex Mono', monospace",
+                            'text-background-color': '#0d1117',
+                            'text-background-opacity': 0.85,
                             'text-background-padding': '3px'
                         }}
                     }},
@@ -143,8 +215,8 @@ fn generate_html(report: &AffectedReport) -> String {
                         selector: 'edge[type="implicit"]',
                         style: {{
                             'line-style': 'dashed',
-                            'line-color': '#f59e0b',
-                            'target-arrow-color': '#f59e0b'
+                            'line-color': '#e3b341',
+                            'target-arrow-color': '#e3b341'
                         }}
                     }}
                 ],
@@ -310,473 +382,820 @@ fn generate_html(report: &AffectedReport) -> String {
         }}
     </script>
     <style>
-        * {{
+        :root {{
+            --bg:            #0d1117;
+            --bg-surface:    #161b22;
+            --bg-surface-2:  #1c2128;
+            --bg-elevated:   #21262d;
+            --border:        #30363d;
+            --border-subtle: #21262d;
+            --text:          #e6edf3;
+            --text-muted:    #8b949e;
+            --text-subtle:   #6e7681;
+            --accent:        #f26f0d;
+            --accent-soft:   rgba(242, 111, 13, 0.12);
+            --accent-ring:   rgba(242, 111, 13, 0.35);
+            --accent-2:      #d2a8ff;
+            --accent-3:      #79c0ff;
+            --accent-4:      #56d364;
+            --warn:          #e3b341;
+            --slate:         #94a3b8;
+            --font-sans:     'IBM Plex Sans', system-ui, -apple-system, sans-serif;
+            --font-mono:     'IBM Plex Mono', 'JetBrains Mono', ui-monospace, monospace;
+            --radius:        8px;
+            --radius-sm:     4px;
+            --radius-pill:   999px;
+        }}
+
+        *, *::before, *::after {{
+            box-sizing: border-box;
             margin: 0;
             padding: 0;
-            box-sizing: border-box;
+        }}
+
+        html {{
+            scroll-behavior: smooth;
+            scroll-padding-top: 72px;
         }}
 
         body {{
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            background: #1a1a1a;
-            color: #e0e0e0;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
+            font-size: 14px;
             line-height: 1.6;
+            font-feature-settings: "ss01", "cv11";
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            min-height: 100vh;
+            background-image:
+                radial-gradient(circle at 20% -10%, rgba(242,111,13,0.04) 0%, transparent 40%),
+                radial-gradient(circle at 80% 110%, rgba(121,192,255,0.03) 0%, transparent 50%);
+            background-attachment: fixed;
         }}
 
-        .container {{
-            max-width: 1400px;
-            margin: 0 auto;
-            padding: 2rem;
+        a {{
+            color: var(--accent-3);
+            text-decoration: none;
         }}
 
-        header {{
+        a:hover {{
+            text-decoration: underline;
+            text-underline-offset: 3px;
+        }}
+
+        code, .mono {{
+            font-family: var(--font-mono);
+            font-size: 0.92em;
+        }}
+
+        /* ── Top bar ────────────────────────────────────────────────── */
+        .topbar {{
             position: sticky;
             top: 0;
             z-index: 100;
-            background: #1a1a1a;
-            text-align: center;
-            padding: 2rem 0 1rem 0;
-            margin-bottom: 2rem;
-            border-bottom: 1px solid #3a3a3a;
-        }}
-
-        h1 {{
-            font-size: 2.5rem;
-            font-weight: 700;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-            margin-bottom: 0.5rem;
-        }}
-
-        .subtitle {{
-            color: #888;
-            font-size: 1.1rem;
-        }}
-
-        .summary {{
-            background: #2a2a2a;
-            border-radius: 12px;
-            padding: 1.5rem;
-            margin-bottom: 2rem;
-            border: 1px solid #3a3a3a;
-        }}
-
-        .summary-grid {{
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 1.5rem;
-        }}
-
-        .summary-item {{
-            text-align: center;
-        }}
-
-        .summary-value {{
-            font-size: 2rem;
-            font-weight: 700;
-            color: #667eea;
-        }}
-
-        .summary-label {{
-            color: #888;
-            font-size: 0.9rem;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-        }}
-
-        .graph-container {{
-            background: #2a2a2a;
-            border-radius: 12px;
-            padding: 2rem;
-            margin-bottom: 2rem;
-            border: 1px solid #3a3a3a;
-        }}
-
-        .graph-legend {{
-            display: flex;
-            gap: 2rem;
-            margin-bottom: 1.5rem;
-            padding: 1rem;
-            background: #1a1a1a;
-            border-radius: 8px;
-            border: 1px solid #3a3a3a;
-            flex-wrap: wrap;
-        }}
-
-        .legend-item {{
             display: flex;
             align-items: center;
-            gap: 0.5rem;
-            font-size: 0.85rem;
-            color: #aaa;
+            gap: 20px;
+            height: 56px;
+            padding: 0 28px;
+            background: rgba(13, 17, 23, 0.82);
+            backdrop-filter: saturate(180%) blur(12px);
+            -webkit-backdrop-filter: saturate(180%) blur(12px);
+            border-bottom: 1px solid var(--border-subtle);
         }}
 
-        .legend-icon {{
-            width: 32px;
-            height: 32px;
-            border-radius: 6px;
+        .brand {{
             display: flex;
             align-items: center;
-            justify-content: center;
-            font-size: 1rem;
-        }}
-
-        .legend-icon.direct {{
-            background: #10b981;
-            border: 3px solid #059669;
-        }}
-
-        .legend-icon.affected {{
-            background: #3b82f6;
-            border: 2px solid #2563eb;
-        }}
-
-        .legend-line {{
-            width: 40px;
-            height: 2px;
-            position: relative;
-        }}
-
-        .legend-line.normal {{
-            background: #667eea;
-        }}
-
-        .legend-line.normal::after {{
-            content: '▶';
-            position: absolute;
-            right: -8px;
-            top: -7px;
-            color: #667eea;
-            font-size: 12px;
-        }}
-
-        .legend-line.implicit {{
-            background: #f59e0b;
-            border-top: 2px dashed #f59e0b;
-        }}
-
-        .legend-line.implicit::after {{
-            content: '▶';
-            position: absolute;
-            right: -8px;
-            top: -9px;
-            color: #f59e0b;
-            font-size: 12px;
-        }}
-
-        #cy {{
-            width: 100%;
-            height: 600px;
-            background: #1a1a1a;
-            border-radius: 8px;
-        }}
-
-        .layout-controls {{
-            display: flex;
-            align-items: center;
-            gap: 1rem;
-            margin-bottom: 1rem;
-            padding: 1rem;
-            background: #1a1a1a;
-            border-radius: 8px;
-            border: 1px solid #3a3a3a;
-        }}
-
-        .layout-label {{
-            color: #888;
-            font-size: 0.9rem;
+            gap: 10px;
+            color: var(--text);
             font-weight: 600;
+            font-size: 15px;
+            letter-spacing: -0.01em;
+        }}
+
+        .brand:hover {{
+            text-decoration: none;
+            color: var(--text);
+        }}
+
+        .brand svg {{
+            width: 28px;
+            height: 28px;
+            display: block;
+        }}
+
+        .brand-version {{
+            font-family: var(--font-mono);
+            font-size: 11px;
+            font-weight: 500;
+            color: var(--text-muted);
+            background: var(--bg-elevated);
+            border: 1px solid var(--border);
+            padding: 2px 8px;
+            border-radius: var(--radius-pill);
+            letter-spacing: 0.02em;
+        }}
+
+        .topbar-eyebrow {{
+            font-family: var(--font-mono);
+            font-size: 11px;
             text-transform: uppercase;
-            letter-spacing: 0.05em;
+            letter-spacing: 0.12em;
+            color: var(--text-subtle);
+            padding-left: 20px;
+            border-left: 1px solid var(--border-subtle);
+        }}
+
+        .topbar-actions {{
+            margin-left: auto;
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }}
+
+        .topbar-link {{
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            color: var(--text-muted);
+            font-size: 13px;
+            font-weight: 500;
+            padding: 6px 12px;
+            border-radius: var(--radius-sm);
+            transition: color 120ms ease, background 120ms ease;
+        }}
+
+        .topbar-link:hover {{
+            color: var(--text);
+            background: var(--bg-elevated);
+            text-decoration: none;
+        }}
+
+        .topbar-link svg:first-child {{
+            opacity: 0.85;
+        }}
+
+        .topbar-link svg:last-child {{
+            opacity: 0.6;
+        }}
+
+        /* ── Main container ────────────────────────────────────────── */
+        .container {{
+            max-width: 1240px;
+            margin: 0 auto;
+            padding: 56px 28px 80px;
+        }}
+
+        /* ── Hero ──────────────────────────────────────────────────── */
+        .hero {{
+            margin-bottom: 56px;
+        }}
+
+        .hero-eyebrow {{
+            font-family: var(--font-mono);
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.16em;
+            color: var(--text-subtle);
+            margin-bottom: 20px;
+            display: flex;
+            align-items: center;
+            gap: 14px;
+        }}
+
+        .hero-eyebrow::before {{
+            content: '';
+            display: inline-block;
+            width: 24px;
+            height: 1px;
+            background: var(--accent);
+        }}
+
+        .hero-title {{
+            display: flex;
+            align-items: baseline;
+            gap: 20px;
+            flex-wrap: wrap;
+            font-weight: 400;
+            letter-spacing: -0.02em;
+            margin-bottom: 28px;
+        }}
+
+        .hero-count {{
+            font-family: var(--font-mono);
+            font-size: clamp(48px, 7vw, 84px);
+            font-weight: 600;
+            font-variant-numeric: tabular-nums;
+            line-height: 1;
+            color: var(--text);
+        }}
+
+        .hero-label {{
+            font-size: clamp(22px, 2.4vw, 30px);
+            font-weight: 300;
+            color: var(--text-muted);
+            line-height: 1.2;
+        }}
+
+        /* ── Global-invalidation banner ────────────────────────────── */
+        .global-banner {{
+            position: relative;
+            background: var(--bg-surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            padding: 24px 28px 24px 32px;
+            margin-bottom: 40px;
+            overflow: hidden;
+        }}
+
+        .global-banner::before {{
+            content: '';
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--accent);
+        }}
+
+        .global-banner-head {{
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            margin-bottom: 12px;
+        }}
+
+        .global-banner-head svg {{
+            color: var(--accent);
+            flex-shrink: 0;
+        }}
+
+        .global-banner h3 {{
+            font-size: 16px;
+            font-weight: 600;
+            color: var(--text);
+            margin: 0;
+            letter-spacing: -0.005em;
+        }}
+
+        .global-banner p {{
+            font-size: 13.5px;
+            color: var(--text-muted);
+            line-height: 1.65;
+            margin: 8px 0;
+            max-width: 78ch;
+        }}
+
+        .global-banner p strong {{
+            color: var(--text);
+            font-weight: 600;
+        }}
+
+        .global-banner-list {{
+            margin: 16px 0 14px;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }}
+
+        .global-banner-row {{
+            display: grid;
+            grid-template-columns: minmax(200px, 1fr) auto minmax(140px, 1fr);
+            align-items: center;
+            gap: 16px;
+            padding: 8px 14px;
+            background: var(--bg);
+            border: 1px solid var(--border-subtle);
+            border-radius: var(--radius-sm);
+            font-family: var(--font-mono);
+            font-size: 12.5px;
+        }}
+
+        .global-banner-row .file {{
+            color: var(--text);
+            font-weight: 500;
+        }}
+
+        .global-banner-row .arrow {{
+            color: var(--text-subtle);
+            font-size: 11px;
+        }}
+
+        .global-banner-row .input {{
+            color: var(--accent);
+            font-weight: 500;
+        }}
+
+        .global-banner-row .pattern {{
+            grid-column: 1 / -1;
+            font-size: 11px;
+            color: var(--text-subtle);
+            border-top: 1px dashed var(--border-subtle);
+            padding-top: 6px;
+            margin-top: 2px;
+        }}
+
+        .global-banner .docs-link {{
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            color: var(--accent-3);
+            font-size: 13px;
+            font-weight: 500;
+            margin-top: 4px;
+        }}
+
+        /* ── Stats grid ────────────────────────────────────────────── */
+        .stats-grid {{
+            display: grid;
+            grid-template-columns: repeat(4, minmax(0, 1fr));
+            gap: 12px;
+            margin-bottom: 32px;
+        }}
+
+        .stat-card {{
+            background: var(--bg-surface);
+            border: 1px solid var(--border-subtle);
+            border-radius: var(--radius);
+            padding: 22px 22px 20px;
+            position: relative;
+            overflow: hidden;
+        }}
+
+        .stat-card-accent::before {{
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 22px;
+            width: 18px;
+            height: 2px;
+            background: var(--accent);
+        }}
+
+        .stat-value {{
+            font-family: var(--font-mono);
+            font-size: 36px;
+            font-weight: 500;
+            font-variant-numeric: tabular-nums;
+            color: var(--text);
+            letter-spacing: -0.02em;
+            line-height: 1.1;
+            margin-bottom: 8px;
+        }}
+
+        .stat-label {{
+            font-size: 11px;
+            font-weight: 500;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: var(--text-subtle);
+        }}
+
+        @media (max-width: 980px) {{
+            .stats-grid {{
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }}
+        }}
+
+        @media (max-width: 520px) {{
+            .stats-grid {{
+                grid-template-columns: 1fr;
+            }}
+        }}
+
+        /* ── Card primitive ────────────────────────────────────────── */
+        .card {{
+            background: var(--bg-surface);
+            border: 1px solid var(--border-subtle);
+            border-radius: var(--radius);
+            margin-bottom: 32px;
+            overflow: hidden;
+        }}
+
+        .card-header {{
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 16px;
+            padding: 20px 24px 4px;
+        }}
+
+        .card-title {{
+            font-size: 15px;
+            font-weight: 600;
+            color: var(--text);
+            letter-spacing: -0.005em;
+        }}
+
+        .card-sub {{
+            font-size: 12.5px;
+            color: var(--text-subtle);
+            padding: 0 24px;
+            margin-bottom: 16px;
+        }}
+
+        .card-body {{
+            padding: 0 24px 24px;
+        }}
+
+        /* ── Graph card ────────────────────────────────────────────── */
+        .graph-toolbar {{
+            display: flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 14px;
+            padding: 12px 24px;
+            background: var(--bg);
+            border-top: 1px solid var(--border-subtle);
+            border-bottom: 1px solid var(--border-subtle);
+        }}
+
+        .toolbar-label {{
+            font-family: var(--font-mono);
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: var(--text-subtle);
         }}
 
         .layout-buttons {{
             display: flex;
-            gap: 0.5rem;
             flex-wrap: wrap;
+            gap: 4px;
         }}
 
         .layout-btn {{
-            background: #2a2a2a;
-            color: #e0e0e0;
-            border: 1px solid #3a3a3a;
-            padding: 0.5rem 1rem;
-            border-radius: 6px;
-            font-size: 0.85rem;
+            font-family: var(--font-mono);
+            font-size: 12px;
             font-weight: 500;
+            color: var(--text-muted);
+            background: transparent;
+            border: 1px solid transparent;
+            padding: 5px 11px;
+            border-radius: var(--radius-sm);
             cursor: pointer;
-            transition: all 0.2s;
+            transition: color 120ms, background 120ms, border-color 120ms;
         }}
 
         .layout-btn:hover {{
-            background: #3a3a3a;
-            border-color: #667eea;
-            transform: translateY(-1px);
+            color: var(--text);
+            background: var(--bg-elevated);
         }}
 
         .layout-btn.active {{
-            background: #667eea;
-            border-color: #667eea;
-            color: #fff;
+            color: var(--text);
+            background: var(--accent-soft);
+            border-color: var(--accent-ring);
         }}
 
-        .layout-btn:active {{
-            transform: translateY(0);
+        .graph-legend {{
+            display: flex;
+            flex-wrap: wrap;
+            gap: 18px;
+            padding: 14px 24px;
+            background: var(--bg);
+            border-bottom: 1px solid var(--border-subtle);
+            font-size: 12px;
+            color: var(--text-muted);
         }}
 
-        .details-container {{
-            background: #2a2a2a;
-            border-radius: 12px;
-            padding: 2rem;
-            border: 1px solid #3a3a3a;
+        .legend-item {{
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
         }}
 
+        .legend-dot {{
+            width: 10px;
+            height: 10px;
+            border-radius: 2px;
+        }}
+
+        .legend-dot.direct  {{ background: var(--accent); }}
+        .legend-dot.affected{{ background: var(--accent-3); }}
+
+        .legend-line {{
+            width: 22px;
+            height: 0;
+            border-top: 1.5px solid var(--text-subtle);
+        }}
+
+        .legend-line.implicit {{
+            border-top-style: dashed;
+            border-top-color: var(--warn);
+        }}
+
+        #cy {{
+            width: 100%;
+            height: 540px;
+            background: var(--bg);
+        }}
+
+        /* ── Filter bar ────────────────────────────────────────────── */
         .filter-controls {{
             display: flex;
-            gap: 0.5rem;
-            margin-bottom: 1.5rem;
+            align-items: center;
+            gap: 4px;
+            padding: 12px 24px;
+            background: var(--bg);
+            border-top: 1px solid var(--border-subtle);
+            border-bottom: 1px solid var(--border-subtle);
+            flex-wrap: wrap;
         }}
 
         .filter-btn {{
-            background: #2a2a2a;
-            color: #e0e0e0;
-            border: 1px solid #3a3a3a;
-            padding: 0.5rem 1rem;
-            border-radius: 6px;
-            font-size: 0.85rem;
+            font-family: var(--font-mono);
+            font-size: 12px;
             font-weight: 500;
+            color: var(--text-muted);
+            background: transparent;
+            border: 1px solid transparent;
+            padding: 5px 12px;
+            border-radius: var(--radius-pill);
             cursor: pointer;
-            transition: all 0.2s;
+            transition: color 120ms, background 120ms, border-color 120ms;
         }}
 
         .filter-btn:hover {{
-            background: #3a3a3a;
-            border-color: #667eea;
+            color: var(--text);
+            background: var(--bg-elevated);
         }}
 
         .filter-btn.active {{
-            background: #667eea;
-            border-color: #667eea;
-            color: #fff;
+            color: var(--text);
+            background: var(--accent-soft);
+            border-color: var(--accent-ring);
+        }}
+
+        .ghost-btn {{
+            font-family: var(--font-mono);
+            font-size: 12px;
+            color: var(--text-muted);
+            background: transparent;
+            border: 1px solid var(--border);
+            padding: 5px 12px;
+            border-radius: var(--radius-sm);
+            cursor: pointer;
+            transition: color 120ms, background 120ms;
+        }}
+
+        .ghost-btn:hover {{
+            color: var(--text);
+            background: var(--bg-elevated);
+        }}
+
+        /* ── Project cards ─────────────────────────────────────────── */
+        .details-body {{
+            padding: 8px 24px 24px;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }}
+
+        .project-card {{
+            background: var(--bg);
+            border: 1px solid var(--border-subtle);
+            border-radius: var(--radius);
+            transition: border-color 120ms ease;
+        }}
+
+        .project-card:hover {{
+            border-color: var(--border);
         }}
 
         .project-card.hidden {{
             display: none;
         }}
 
-        .project-card {{
-            background: #222;
-            border-radius: 8px;
-            margin-bottom: 1rem;
-            border-left: 4px solid #667eea;
-        }}
-
-        .project-card details {{
+        .project-card > details > summary {{
             cursor: pointer;
-        }}
-
-        .project-card summary {{
-            padding: 1.5rem;
             list-style: none;
             display: flex;
             align-items: center;
-            gap: 1rem;
+            justify-content: space-between;
+            gap: 16px;
+            padding: 14px 18px;
             user-select: none;
         }}
 
-        .project-card summary::-webkit-details-marker {{
+        .project-card > details > summary::-webkit-details-marker {{
             display: none;
         }}
 
-        .project-card summary::before {{
-            content: '▶';
+        .project-card > details > summary::before {{
+            content: '';
             display: inline-block;
-            width: 1em;
-            transition: transform 0.2s;
-            color: #667eea;
+            width: 0;
+            height: 0;
+            border-left: 5px solid var(--text-subtle);
+            border-top: 4px solid transparent;
+            border-bottom: 4px solid transparent;
+            transition: transform 120ms;
+            flex-shrink: 0;
         }}
 
-        .project-card details[open] summary::before {{
+        .project-card > details[open] > summary::before {{
             transform: rotate(90deg);
         }}
 
         .project-name {{
-            font-size: 1.3rem;
-            font-weight: 600;
-            color: #fff;
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--text);
             flex: 1;
+            min-width: 0;
+        }}
+
+        .project-name svg {{
+            color: var(--text-subtle);
+            flex-shrink: 0;
         }}
 
         .badge-container {{
-            display: flex;
-            gap: 0.5rem;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            flex-shrink: 0;
         }}
 
         .affect-badge {{
-            padding: 0.35rem 0.75rem;
-            border-radius: 12px;
-            font-size: 0.75rem;
-            font-weight: 600;
+            font-family: var(--font-mono);
+            font-size: 10.5px;
+            font-weight: 500;
             text-transform: uppercase;
-            letter-spacing: 0.05em;
+            letter-spacing: 0.06em;
+            padding: 3px 9px;
+            border-radius: var(--radius-pill);
+            border: 1px solid var(--border);
+            color: var(--text-muted);
+            background: var(--bg-elevated);
         }}
 
-        .badge-direct {{
-            background: #10b981;
-            color: #fff;
+        .affect-badge.badge-direct {{
+            color: var(--accent);
+            border-color: var(--accent-ring);
+            background: var(--accent-soft);
         }}
 
-        .badge-affected {{
-            background: #3b82f6;
-            color: #fff;
+        .affect-badge.badge-affected {{
+            color: var(--accent-3);
+            border-color: rgba(121, 192, 255, 0.3);
+            background: rgba(121, 192, 255, 0.08);
         }}
 
-        .badge-both {{
-            background: linear-gradient(90deg, #10b981 0%, #3b82f6 100%);
-            color: #fff;
+        .affect-badge.badge-both {{
+            color: var(--text);
+            border-color: var(--border);
+            background: var(--bg-elevated);
         }}
 
         .cause-list-container {{
-            padding: 0 1.5rem 1.5rem 1.5rem;
-        }}
-
-        .toggle-all-btn {{
-            background: #667eea;
-            color: #fff;
-            border: none;
-            padding: 0.75rem 1.5rem;
-            border-radius: 8px;
-            font-size: 0.95rem;
-            font-weight: 600;
-            cursor: pointer;
-            margin-bottom: 1.5rem;
-            transition: all 0.2s;
-            display: inline-flex;
-            align-items: center;
-            gap: 0.5rem;
-        }}
-
-        .toggle-all-btn:hover {{
-            background: #5a67d8;
-            transform: translateY(-1px);
-            box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
-        }}
-
-        .toggle-all-btn:active {{
-            transform: translateY(0);
+            padding: 4px 18px 18px 18px;
         }}
 
         .cause-list {{
             list-style: none;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
         }}
 
         .cause-item {{
-            background: #1a1a1a;
-            border-radius: 6px;
-            padding: 1rem;
-            margin-bottom: 0.75rem;
-            border-left: 3px solid #444;
+            background: var(--bg-surface);
+            border: 1px solid var(--border-subtle);
+            border-left: 2px solid var(--border);
+            border-radius: var(--radius-sm);
+            padding: 12px 14px;
         }}
+
+        /* Each cause-item gets its left edge tinted to match the pill,
+           so a glance reveals the cause type without reading the pill. */
+        .cause-item:has(.cause-type.direct)   {{ border-left-color: var(--accent); }}
+        .cause-item:has(.cause-type.imported) {{ border-left-color: var(--accent-3); }}
+        .cause-item:has(.cause-type.reexported){{ border-left-color: var(--accent-2); }}
+        .cause-item:has(.cause-type.implicit) {{ border-left-color: var(--accent-4); }}
+        .cause-item:has(.cause-type.asset)    {{ border-left-color: var(--accent-3); }}
+        .cause-item:has(.cause-type.lockfile) {{ border-left-color: var(--warn); }}
+        .cause-item:has(.cause-type.global)   {{ border-left-color: var(--slate); }}
 
         .cause-type {{
             display: inline-block;
-            background: #667eea;
-            color: #fff;
-            padding: 0.25rem 0.75rem;
-            border-radius: 4px;
-            font-size: 0.85rem;
-            font-weight: 600;
-            margin-bottom: 0.5rem;
+            font-family: var(--font-mono);
+            font-size: 10.5px;
+            font-weight: 500;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            padding: 3px 9px;
+            border-radius: var(--radius-pill);
+            margin-bottom: 8px;
+            color: var(--text-muted);
+            background: var(--bg-elevated);
+            border: 1px solid var(--border);
         }}
 
         .cause-type.direct {{
-            background: #10b981;
+            color: var(--accent);
+            background: var(--accent-soft);
+            border-color: var(--accent-ring);
         }}
 
         .cause-type.imported {{
-            background: #3b82f6;
+            color: var(--accent-3);
+            background: rgba(121, 192, 255, 0.10);
+            border-color: rgba(121, 192, 255, 0.30);
         }}
 
         .cause-type.reexported {{
-            background: #8b5cf6;
+            color: var(--accent-2);
+            background: rgba(210, 168, 255, 0.10);
+            border-color: rgba(210, 168, 255, 0.30);
         }}
 
         .cause-type.implicit {{
-            background: #f59e0b;
+            color: var(--accent-4);
+            background: rgba(86, 211, 100, 0.10);
+            border-color: rgba(86, 211, 100, 0.30);
         }}
 
-        /* Distinct pill for Nx namedInputs global invalidation. Deliberately
-           a neutral slate so the user reads it as "infrastructure rule fired"
-           rather than "real direct code change" (which uses .direct/green). */
+        .cause-type.asset {{
+            color: #56d3c5;
+            background: rgba(86, 211, 197, 0.10);
+            border-color: rgba(86, 211, 197, 0.28);
+        }}
+
+        .cause-type.lockfile {{
+            color: var(--warn);
+            background: rgba(227, 179, 65, 0.10);
+            border-color: rgba(227, 179, 65, 0.30);
+        }}
+
         .cause-type.global {{
-            background: #64748b;
+            color: var(--slate);
+            background: rgba(148, 163, 184, 0.10);
+            border-color: rgba(148, 163, 184, 0.30);
         }}
 
-        .global-banner {{
-            background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
-            border: 1px solid #475569;
-            border-left: 4px solid #64748b;
-            border-radius: 8px;
-            padding: 1.25rem 1.5rem;
-            margin-bottom: 1.5rem;
-            color: #e2e8f0;
+        .cause-details {{
+            color: var(--text-muted);
+            font-size: 13px;
+            line-height: 1.6;
         }}
 
-        .global-banner h3 {{
-            margin: 0 0 0.5rem 0;
-            color: #f1f5f9;
-            font-size: 1.1rem;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
+        .code-path {{
+            font-family: var(--font-mono);
+            background: var(--bg);
+            padding: 1px 6px;
+            border-radius: 3px;
+            color: var(--accent);
+            font-size: 0.92em;
+            border: 1px solid var(--border-subtle);
         }}
 
-        .global-banner p {{
-            margin: 0.5rem 0;
-            color: #cbd5e1;
-            font-size: 0.95rem;
-            line-height: 1.5;
+        .symbol {{
+            font-family: var(--font-mono);
+            background: var(--bg);
+            padding: 1px 6px;
+            border-radius: 3px;
+            color: var(--accent-2);
+            font-size: 0.92em;
+            border: 1px solid var(--border-subtle);
         }}
 
-        .global-banner ul {{
-            margin: 0.75rem 0 0.5rem 0;
-            padding-left: 1.5rem;
-            color: #e2e8f0;
+        .cause-details code {{
+            font-family: var(--font-mono);
+            color: var(--text);
+            background: var(--bg);
+            padding: 1px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+            border: 1px solid var(--border-subtle);
         }}
 
-        .global-banner ul li {{
-            margin: 0.25rem 0;
-            font-size: 0.9rem;
-        }}
-
-        .global-banner .docs-link {{
-            color: #93c5fd;
-            text-decoration: none;
-            border-bottom: 1px dotted #93c5fd;
-        }}
-
-        .global-banner .docs-link:hover {{
-            color: #bfdbfe;
-        }}
-
+        /* ── Collapsed global-only group ───────────────────────────── */
         .global-only-group {{
-            margin-top: 2rem;
-            background: #1a1a1a;
-            border: 1px solid #2a2a2a;
-            border-left: 4px solid #64748b;
-            border-radius: 8px;
-            padding: 1rem 1.25rem;
+            margin-top: 24px;
+            background: var(--bg);
+            border: 1px solid var(--border-subtle);
+            border-left: 2px solid var(--slate);
+            border-radius: var(--radius);
+            padding: 14px 18px;
         }}
 
         .global-only-group > summary {{
             cursor: pointer;
             list-style: none;
-            color: #cbd5e1;
-            font-weight: 600;
-            font-size: 1rem;
+            color: var(--text-muted);
+            font-size: 13px;
+            font-family: var(--font-mono);
             user-select: none;
+            display: flex;
+            align-items: center;
+            gap: 10px;
         }}
 
         .global-only-group > summary::-webkit-details-marker {{
@@ -784,113 +1203,219 @@ fn generate_html(report: &AffectedReport) -> String {
         }}
 
         .global-only-group > summary::before {{
-            content: '▸';
+            content: '';
             display: inline-block;
-            margin-right: 0.5rem;
-            transition: transform 0.15s ease;
+            width: 0;
+            height: 0;
+            border-left: 5px solid var(--text-subtle);
+            border-top: 4px solid transparent;
+            border-bottom: 4px solid transparent;
+            transition: transform 120ms;
+            flex-shrink: 0;
         }}
 
         .global-only-group[open] > summary::before {{
             transform: rotate(90deg);
         }}
 
-        .global-only-group .global-only-inner {{
-            margin-top: 1rem;
+        .global-only-group > summary strong {{
+            color: var(--text);
+            font-weight: 500;
         }}
 
-        .cause-details {{
-            color: #aaa;
-            font-size: 0.9rem;
-            margin-top: 0.5rem;
+        .global-only-inner {{
+            margin-top: 12px;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
         }}
 
-        .code-path {{
-            font-family: 'Monaco', 'Menlo', 'Courier New', monospace;
-            background: #111;
-            padding: 0.25rem 0.5rem;
-            border-radius: 3px;
-            color: #60a5fa;
-            font-size: 0.85rem;
+        /* ── Footer ────────────────────────────────────────────────── */
+        .footer {{
+            border-top: 1px solid var(--border-subtle);
+            padding: 32px 28px 48px;
+            margin-top: 24px;
         }}
 
-        .symbol {{
-            font-family: 'Monaco', 'Menlo', 'Courier New', monospace;
-            background: #111;
-            padding: 0.25rem 0.5rem;
-            border-radius: 3px;
-            color: #a78bfa;
-            font-size: 0.85rem;
+        .footer-grid {{
+            max-width: 1240px;
+            margin: 0 auto;
+            display: grid;
+            grid-template-columns: 1.4fr 1fr 1fr;
+            gap: 32px;
+            align-items: start;
         }}
 
-        footer {{
-            text-align: center;
-            margin-top: 3rem;
-            padding-top: 2rem;
-            border-top: 1px solid #3a3a3a;
-            color: #666;
+        @media (max-width: 720px) {{
+            .footer-grid {{
+                grid-template-columns: 1fr;
+                gap: 20px;
+            }}
+        }}
+
+        .footer-brand {{
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }}
+
+        .footer-brand-row {{
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            color: var(--text);
+            font-weight: 600;
+            font-size: 14px;
+        }}
+
+        .footer-brand-row svg {{
+            width: 22px;
+            height: 22px;
+        }}
+
+        .footer-sub {{
+            font-size: 12.5px;
+            color: var(--text-subtle);
+            max-width: 32ch;
+        }}
+
+        .footer-col-title {{
+            font-family: var(--font-mono);
+            font-size: 10.5px;
+            text-transform: uppercase;
+            letter-spacing: 0.12em;
+            color: var(--text-subtle);
+            margin-bottom: 8px;
+        }}
+
+        .footer-col p {{
+            font-size: 13px;
+            color: var(--text-muted);
+            line-height: 1.7;
+            max-width: 36ch;
+        }}
+
+        .footer-col p code {{
+            /* Keep code chips on a single line so `nx affected` / `#domino-meta`
+               don't fragment in the middle of a name. */
+            white-space: nowrap;
+        }}
+
+        .footer-col a {{
+            font-size: 13px;
+            color: var(--text-muted);
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }}
+
+        .footer-col code {{
+            font-family: var(--font-mono);
+            color: var(--accent);
+        }}
+
+        .footer-links {{
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }}
+
+        /* ── Motion ────────────────────────────────────────────────── */
+        @media (prefers-reduced-motion: no-preference) {{
+            .hero, .global-banner, .stats-grid, .card {{
+                animation: domino-fade-up 320ms cubic-bezier(0.16, 1, 0.3, 1) backwards;
+            }}
+            .hero          {{ animation-delay: 0ms; }}
+            .global-banner {{ animation-delay: 40ms; }}
+            .stats-grid    {{ animation-delay: 80ms; }}
+            .card          {{ animation-delay: 120ms; }}
+
+            @keyframes domino-fade-up {{
+                from {{ opacity: 0; transform: translateY(8px); }}
+                to   {{ opacity: 1; transform: translateY(0);   }}
+            }}
+        }}
+
+        /* ── Focus visibility ──────────────────────────────────────── */
+        :focus-visible {{
+            outline: 2px solid var(--accent);
+            outline-offset: 2px;
+            border-radius: var(--radius-sm);
+        }}
+
+        /* ── Print ─────────────────────────────────────────────────── */
+        @media print {{
+            .topbar, .graph-toolbar, .filter-controls, .ghost-btn {{ display: none; }}
+            body {{ background: #fff; color: #000; }}
+            .card, .stat-card, .project-card, .global-banner {{
+                background: #fff;
+                border-color: #ddd;
+                page-break-inside: avoid;
+            }}
         }}
     </style>
 </head>
 <body>
-    {}
-    <div class="container">
-        <header>
-            <h1>🎯 True Affected Report</h1>
-            <p class="subtitle">Dependency Graph & Impact Analysis</p>
-        </header>
-
-        {}
-
-        <div class="summary">
-            <div class="summary-grid">
-                <div class="summary-item">
-                    <div class="summary-value">{}</div>
-                    <div class="summary-label">Affected Projects</div>
-                </div>
-                <div class="summary-item">
-                    <div class="summary-value">{}</div>
-                    <div class="summary-label">Total Causes</div>
-                </div>
-                <div class="summary-item" style="{}">
-                    <div class="summary-value">{}</div>
-                    <div class="summary-label">Globally Invalidated</div>
-                </div>
-                <div class="summary-item" style="{}">
-                    <div class="summary-value">{}</div>
-                    <div class="summary-label">Semantically Affected</div>
-                </div>
-                <div class="summary-item">
-                    <div class="summary-value">{}</div>
-                    <div class="summary-label">Changed Files</div>
-                </div>
-            </div>
+    {metadata}
+    <header class="topbar">
+        <a class="brand" href="{repo}" target="_blank" rel="noopener noreferrer" aria-label="domino on GitHub">
+            {logo}
+            <span>domino</span>
+            <span class="brand-version">v{version}</span>
+        </a>
+        <span class="topbar-eyebrow">Affected Projects Report</span>
+        <div class="topbar-actions">
+            <a class="topbar-link" href="{repo}" target="_blank" rel="noopener noreferrer">
+                {icon_github}
+                <span>Star on GitHub</span>
+                {icon_external}
+            </a>
         </div>
+    </header>
 
-        <div class="graph-container">
-            <h2 style="margin-bottom: 1.5rem; color: #fff;">Interactive Dependency Graph</h2>
-            <p style="margin-bottom: 1rem; color: #888; font-size: 0.9rem;">
-                💡 Pan, zoom, and drag nodes to explore • Hover over nodes for details
-            </p>
-            <div class="graph-legend">
-                <div class="legend-item">
-                    <div class="legend-icon direct">✏️</div>
-                    <span>Direct Change</span>
-                </div>
-                <div class="legend-item">
-                    <div class="legend-icon affected">📦</div>
-                    <span>Affected Project</span>
-                </div>
-                <div class="legend-item">
-                    <div class="legend-line normal"></div>
-                    <span>Import Dependency</span>
-                </div>
-                <div class="legend-item">
-                    <div class="legend-line implicit"></div>
-                    <span>Implicit Dependency</span>
-                </div>
+    <main class="container">
+        <section class="hero" aria-labelledby="hero-title">
+            <div class="hero-eyebrow">Generated {eyebrow} &middot; v{version}</div>
+            <h1 class="hero-title" id="hero-title">
+                <span class="hero-count">{count}</span>
+                <span class="hero-label">project{plural} affected</span>
+            </h1>
+        </section>
+
+        <section class="stats-grid" aria-label="Summary statistics">
+            <div class="stat-card">
+                <div class="stat-value">{total_causes}</div>
+                <div class="stat-label">Total Causes</div>
             </div>
-            <div class="layout-controls">
-                <span class="layout-label">Layout:</span>
+            <div class="stat-card stat-card-accent" style="{split_style}">
+                <div class="stat-value">{globally_invalidated}</div>
+                <div class="stat-label">Globally Invalidated</div>
+            </div>
+            <div class="stat-card" style="{split_style}">
+                <div class="stat-value">{semantically_affected}</div>
+                <div class="stat-label">Semantically Affected</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value">{changed_files}</div>
+                <div class="stat-label">Changed Files</div>
+            </div>
+        </section>
+
+        {banner}
+
+        <section class="card graph-card">
+            <header class="card-header">
+                <h2 class="card-title">Dependency graph</h2>
+            </header>
+            <p class="card-sub">Pan, zoom, and drag nodes to explore &mdash; hover for details.</p>
+            <div class="graph-legend">
+                <span class="legend-item"><span class="legend-dot direct"></span>Direct change</span>
+                <span class="legend-item"><span class="legend-dot affected"></span>Affected project</span>
+                <span class="legend-item"><span class="legend-line"></span>Import dependency</span>
+                <span class="legend-item"><span class="legend-line implicit"></span>Implicit dependency</span>
+            </div>
+            <div class="graph-toolbar">
+                <span class="toolbar-label">Layout</span>
                 <div class="layout-buttons">
                     <button class="layout-btn" onclick="switchLayout('fcose'); setActiveButton(this)">fCoSE</button>
                     <button class="layout-btn" onclick="switchLayout('dagre'); setActiveButton(this)">Dagre</button>
@@ -902,42 +1427,68 @@ fn generate_html(report: &AffectedReport) -> String {
                 </div>
             </div>
             <div id="cy"></div>
-        </div>
+        </section>
 
-        <div class="details-container">
-            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;">
-                <h2 style="color: #fff; margin: 0;">Detailed Impact Analysis</h2>
-                <button id="toggleAllBtn" class="toggle-all-btn" onclick="toggleAllDetails()">
-                    ▼ Expand All
-                </button>
-            </div>
+        <section class="card details-card">
+            <header class="card-header">
+                <h2 class="card-title">Detailed impact analysis</h2>
+                <button id="toggleAllBtn" class="ghost-btn" onclick="toggleAllDetails()">Expand all</button>
+            </header>
             <div class="filter-controls">
                 <button class="filter-btn active" onclick="filterProjects('all'); setActiveFilter(this)">All</button>
                 <button class="filter-btn" onclick="filterProjects('direct'); setActiveFilter(this)">Direct</button>
                 <button class="filter-btn" onclick="filterProjects('affected'); setActiveFilter(this)">Affected</button>
                 <button class="filter-btn" onclick="filterProjects('both'); setActiveFilter(this)">Both</button>
             </div>
-            {}
-        </div>
+            <div class="details-body">
+                {details}
+            </div>
+        </section>
+    </main>
 
-        <footer>
-            Generated by <strong>domino</strong> v{} &middot; True Affected Analysis
-        </footer>
-    </div>
+    <footer class="footer">
+        <div class="footer-grid">
+            <div class="footer-col footer-brand">
+                <div class="footer-brand-row">
+                    {logo_small}
+                    <span>domino &middot; v{version}</span>
+                </div>
+                <p class="footer-sub">Semantic change detection for monorepos &mdash; a drop-in <code>nx affected</code> replacement built on the Oxc parser.</p>
+            </div>
+            <div class="footer-col">
+                <div class="footer-col-title">Machine-readable</div>
+                <p>Run metadata is embedded as JSON at <code>#domino-meta</code> in this document.</p>
+            </div>
+            <div class="footer-col footer-links">
+                <div class="footer-col-title">Project</div>
+                <a href="{repo}" target="_blank" rel="noopener noreferrer">{icon_github_sm} GitHub</a>
+                <a href="{repo}/issues" target="_blank" rel="noopener noreferrer">Report an issue {icon_external}</a>
+                <a href="{repo}/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT License {icon_external}</a>
+            </div>
+        </div>
+    </footer>
 </body>
 </html>"#,
-    graph_data,
-    metadata_script,
-    banner_html,
-    format_number(report.projects.len()),
-    format_number(total_causes),
-    summary_split_style,
-    format_number(report.totals.globally_invalidated),
-    summary_split_style,
-    format_number(report.totals.semantically_affected),
-    format_number(report.totals.changed_files),
-    details_html,
-    env!("CARGO_PKG_VERSION"),
+    graph = graph_data,
+    metadata = metadata_script,
+    banner = banner_html,
+    logo = LOGO_SVG,
+    logo_small = LOGO_SVG,
+    favicon = url_encode_svg(LOGO_SVG),
+    repo = REPO_URL,
+    icon_github = ICON_GITHUB,
+    icon_github_sm = ICON_GITHUB,
+    icon_external = ICON_EXTERNAL,
+    eyebrow = format_relative_time(report.run_started_at_unix_secs),
+    version = env!("CARGO_PKG_VERSION"),
+    count = format_number(report.projects.len()),
+    plural = if report.projects.len() == 1 { "" } else { "s" },
+    total_causes = format_number(total_causes),
+    changed_files = format_number(report.totals.changed_files),
+    split_style = summary_split_style,
+    globally_invalidated = format_number(report.totals.globally_invalidated),
+    semantically_affected = format_number(report.totals.semantically_affected),
+    details = details_html,
   )
 }
 
@@ -989,6 +1540,7 @@ fn generate_cytoscape_data(report: &AffectedReport) -> String {
 
   // Build nodes array
   let mut nodes = Vec::new();
+  let mut node_ids: HashSet<String> = HashSet::new();
   for project in &report.projects {
     let node_type = if direct_changes.contains(&project.name) {
       "direct"
@@ -996,27 +1548,29 @@ fn generate_cytoscape_data(report: &AffectedReport) -> String {
       "affected"
     };
 
-    let icon = if node_type == "direct" {
-      "✏️ "
-    } else {
-      "📦 "
-    };
-
+    let node_id = sanitize_node_id(&project.name);
     nodes.push(format!(
-      r#"{{ data: {{ id: "{}", label: "{}{}", type: "{}" }} }}"#,
-      sanitize_node_id(&project.name),
-      icon,
-      project.name,
-      node_type
+      r#"{{ data: {{ id: "{}", label: "{}", type: "{}" }} }}"#,
+      node_id, project.name, node_type
     ));
+    node_ids.insert(node_id);
   }
 
-  // Build edges array
+  // Build edges array. Skip any edge whose source or target isn't in the
+  // node set — cytoscape throws on dangling edges, and a cause may reference
+  // a project that isn't itself on the affected list (e.g. an upstream lib
+  // that the affected detector pruned because nothing else points to it).
   let mut edges = Vec::new();
   for (source, targets) in relationships {
     let source_id = sanitize_node_id(&source);
+    if !node_ids.contains(&source_id) {
+      continue;
+    }
     for (target, cause_types) in targets {
       let target_id = sanitize_node_id(&target);
+      if !node_ids.contains(&target_id) {
+        continue;
+      }
 
       // Count cause types
       let import_count = cause_types.iter().filter(|t| *t == "imported").count();
@@ -1060,39 +1614,48 @@ fn generate_global_banner_html(report: &AffectedReport) -> String {
   let project_count = report.projects.len();
   let trigger_count = report.global_triggers.len();
 
-  let mut items = String::new();
+  let mut rows = String::new();
   for trigger in &report.global_triggers {
-    items.push_str(&format!(
-      "<li><code>{}</code> &nbsp;&larr;&nbsp; matched <code>{}</code></li>",
-      html_escape(&trigger.file.display().to_string()),
-      html_escape(&trigger.named_input),
+    rows.push_str(&format!(
+      r#"<div class="global-banner-row">
+                <span class="file">{file}</span>
+                <span class="arrow">&larr; matched</span>
+                <span class="input">{input}</span>
+                <span class="pattern">{pattern}</span>
+            </div>"#,
+      file = html_escape(&trigger.file.display().to_string()),
+      input = html_escape(&trigger.named_input),
+      pattern = html_escape(&trigger.raw_pattern),
     ));
   }
 
   format!(
-    r#"<div class="global-banner" role="status">
-            <h3>⚠️ Global invalidation detected</h3>
+    r#"<section class="global-banner" role="status" aria-labelledby="gbanner-title">
+            <div class="global-banner-head">
+                {icon}
+                <h3 id="gbanner-title">Global invalidation detected</h3>
+            </div>
             <p>
                 <strong>{trigger_count}</strong> changed file{trigger_plural} matched Nx <code>namedInputs</code>
                 workspace-root pattern{trigger_plural}, so all <strong>{project_count}</strong> projects
                 are marked affected &mdash; the same as <code>nx affected</code> would do.
             </p>
-            <ul>{items}</ul>
+            <div class="global-banner-list">{rows}</div>
             <p>
                 Semantic analysis of the other changed files still ran &mdash; the
-                <em>Detailed Impact Analysis</em> section below separates projects affected by
+                <em>Detailed impact analysis</em> section below separates projects affected by
                 real code signal from those only swept up by the global rule.
-                See the
-                <a class="docs-link" href="https://nx.dev/concepts/more-concepts/customizing-inputs" target="_blank" rel="noopener">
-                    Nx <code>namedInputs</code> docs
-                </a>
-                for the underlying mechanic.
             </p>
-        </div>"#,
+            <a class="docs-link" href="https://nx.dev/concepts/more-concepts/customizing-inputs" target="_blank" rel="noopener noreferrer">
+                Learn how Nx <code>namedInputs</code> work {external}
+            </a>
+        </section>"#,
+    icon = ICON_INFO,
+    external = ICON_EXTERNAL,
     trigger_count = trigger_count,
     trigger_plural = if trigger_count == 1 { "" } else { "s" },
     project_count = format_number(project_count),
-    items = items,
+    rows = rows,
   )
 }
 
@@ -1172,10 +1735,13 @@ fn generate_details_html(report: &AffectedReport) -> String {
 
     for cause in &project.causes {
       match cause {
+        // Real direct-file signals. GlobalInvalidation is deliberately
+        // excluded here — a workspace-rule sweep isn't the same kind of
+        // "direct change" as a real code edit, and conflating them is
+        // exactly the UX bug the global-invalidation work was about.
         AffectCause::DirectChange { .. }
         | AffectCause::AssetChange { .. }
-        | AffectCause::LockfileChange { .. }
-        | AffectCause::GlobalInvalidation { .. } => has_direct = true,
+        | AffectCause::LockfileChange { .. } => has_direct = true,
         AffectCause::ImportedSymbol { .. } => has_imported = true,
         _ => {}
       }
@@ -1188,7 +1754,7 @@ fn generate_details_html(report: &AffectedReport) -> String {
       )
     } else if has_direct {
       (
-        r#"<span class="affect-badge badge-direct">Direct Change</span>"#,
+        r#"<span class="affect-badge badge-direct">Direct</span>"#,
         "direct",
       )
     } else {
@@ -1199,25 +1765,24 @@ fn generate_details_html(report: &AffectedReport) -> String {
     };
 
     html.push_str(&format!(
-      r#"<div class="project-card" data-filter-type="{}">
+      r#"<div class="project-card" data-filter-type="{filter}">
                 <details>
                     <summary>
-                        <div class="project-name">📦 {}</div>
+                        <div class="project-name">{icon}<span>{name}</span></div>
                         <div class="badge-container">
-                            {}
-                            <span class="affect-badge" style="background: #555;">
-                                {} cause{}
-                            </span>
+                            {badge}
+                            <span class="affect-badge">{count} cause{plural}</span>
                         </div>
                     </summary>
                     <div class="cause-list-container">
                         <ul class="cause-list">
 "#,
-      filter_type,
-      project.name,
-      badge,
-      project.causes.len(),
-      if project.causes.len() == 1 { "" } else { "s" }
+      filter = filter_type,
+      icon = ICON_PACKAGE,
+      name = html_escape(&project.name),
+      badge = badge,
+      count = project.causes.len(),
+      plural = if project.causes.len() == 1 { "" } else { "s" }
     ));
 
     for cause in &project.causes {
@@ -1298,7 +1863,7 @@ fn generate_details_html(report: &AffectedReport) -> String {
           referenced_in,
           line,
         } => {
-          html.push_str("<span class=\"cause-type direct\">Asset Change</span>");
+          html.push_str("<span class=\"cause-type asset\">Asset Change</span>");
           html.push_str("<div class=\"cause-details\">");
           html.push_str(&format!(
             "Asset: <span class=\"code-path\">{}</span><br/>",
@@ -1315,7 +1880,7 @@ fn generate_details_html(report: &AffectedReport) -> String {
           dependency,
           importing_file,
         } => {
-          html.push_str("<span class=\"cause-type direct\">Lockfile Change</span>");
+          html.push_str("<span class=\"cause-type lockfile\">Lockfile Change</span>");
           html.push_str("<div class=\"cause-details\">");
           html.push_str(&format!(
             "Dependency: <span class=\"symbol\">{}</span><br/>",
@@ -1351,7 +1916,7 @@ fn generate_details_html(report: &AffectedReport) -> String {
     let group_label = global_only_group_label(&global_only);
     html.push_str(&format!(
       r#"<details class="global-only-group">
-                <summary>{count} projects globally invalidated{label} &mdash; click to expand</summary>
+                <summary><strong>{count}</strong> projects globally invalidated{label}</summary>
                 <div class="global-only-inner">"#,
       count = format_number(global_only.len()),
       label = group_label,
@@ -1362,16 +1927,15 @@ fn generate_details_html(report: &AffectedReport) -> String {
         r#"<div class="project-card" data-filter-type="affected">
                     <details>
                         <summary>
-                            <div class="project-name">📦 {name}</div>
+                            <div class="project-name">{icon}<span>{name}</span></div>
                             <div class="badge-container">
-                                <span class="affect-badge badge-affected">Global Only</span>
-                                <span class="affect-badge" style="background: #555;">
-                                    {count} cause{plural}
-                                </span>
+                                <span class="affect-badge">Global only</span>
+                                <span class="affect-badge">{count} cause{plural}</span>
                             </div>
                         </summary>
                         <div class="cause-list-container">
                             <ul class="cause-list">"#,
+        icon = ICON_PACKAGE,
         name = html_escape(&project.name),
         count = project.causes.len(),
         plural = if project.causes.len() == 1 { "" } else { "s" },
@@ -1422,6 +1986,17 @@ mod tests {
     ReportTotals::default()
   }
 
+  /// Unix seconds for "12 minutes ago" — keeps the sample report's eyebrow
+  /// showing a friendly relative time instead of the >7-day fallback.
+  fn synth_recent_timestamp() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .map(|d| d.as_secs() as i64)
+      .unwrap_or(0);
+    now - 12 * 60
+  }
+
   fn synth_global_report() -> AffectedReport {
     // Mimics the real-world incident: ~600 projects swept up by a workflow
     // file change, ~15 with semantic signal, 3 global trigger files.
@@ -1445,6 +2020,45 @@ mod tests {
         ],
       ));
     }
+    // Two upstream libs that the 15 apps import from. Including them as
+    // real projects (with their own causes) means the dependency graph has
+    // valid edge endpoints — the apps point to `shared-utils`, which in
+    // turn imports from `core`. Without these the synth graph has dangling
+    // edges and cytoscape (rightly) refuses to render.
+    projects.push(make_project(
+      "shared-utils",
+      vec![
+        AffectCause::DirectChange {
+          file: PathBuf::from("libs/shared-utils/src/format.ts"),
+          symbol: Some("formatDate".to_string()),
+          line: 18,
+        },
+        AffectCause::ImportedSymbol {
+          source_project: "core".to_string(),
+          symbol: "Logger".to_string(),
+          via_file: PathBuf::from("libs/shared-utils/src/log.ts"),
+          source_file: PathBuf::from("libs/core/src/logger.ts"),
+        },
+        AffectCause::GlobalInvalidation {
+          file: PathBuf::from(".github/workflows/ci.yml"),
+          named_input: "sharedGlobals".to_string(),
+        },
+      ],
+    ));
+    projects.push(make_project(
+      "core",
+      vec![
+        AffectCause::DirectChange {
+          file: PathBuf::from("libs/core/src/logger.ts"),
+          symbol: Some("Logger".to_string()),
+          line: 42,
+        },
+        AffectCause::GlobalInvalidation {
+          file: PathBuf::from(".github/workflows/ci.yml"),
+          named_input: "sharedGlobals".to_string(),
+        },
+      ],
+    ));
     for i in 0..15 {
       projects.push(make_project(
         &format!("app-{}", i),
@@ -1490,23 +2104,34 @@ mod tests {
       ],
       totals: ReportTotals {
         globally_invalidated: 600,
-        semantically_affected: 15,
-        overlap: 15,
+        semantically_affected: 17,
+        overlap: 17,
         changed_files: 4,
       },
       version: env!("CARGO_PKG_VERSION"),
-      run_started_at_unix_secs: 1_716_595_200,
+      // Recent timestamp so the eyebrow renders a friendly relative time
+      // instead of the >7-day fallback. Computed at runtime in the harness.
+      run_started_at_unix_secs: synth_recent_timestamp(),
     }
   }
 
   fn synth_normal_report() -> AffectedReport {
     let projects = vec![
       make_project(
-        "app-web",
+        "core",
         vec![AffectCause::DirectChange {
-          file: PathBuf::from("apps/web/src/main.ts"),
-          symbol: Some("bootstrap".to_string()),
-          line: 12,
+          file: PathBuf::from("libs/core/src/logger.ts"),
+          symbol: Some("Logger".to_string()),
+          line: 42,
+        }],
+      ),
+      make_project(
+        "app-web",
+        vec![AffectCause::ImportedSymbol {
+          source_project: "shared-utils".to_string(),
+          symbol: "formatDate".to_string(),
+          via_file: PathBuf::from("apps/web/src/main.ts"),
+          source_file: PathBuf::from("libs/shared-utils/src/format.ts"),
         }],
       ),
       make_project(
@@ -1530,12 +2155,14 @@ mod tests {
       global_triggers: Vec::new(),
       totals: ReportTotals {
         globally_invalidated: 0,
-        semantically_affected: 3,
+        semantically_affected: 4,
         overlap: 0,
         changed_files: 2,
       },
       version: env!("CARGO_PKG_VERSION"),
-      run_started_at_unix_secs: 1_716_595_200,
+      // Recent timestamp so the eyebrow renders a friendly relative time
+      // instead of the >7-day fallback. Computed at runtime in the harness.
+      run_started_at_unix_secs: synth_recent_timestamp(),
     }
   }
 
@@ -1546,16 +2173,16 @@ mod tests {
 
     assert!(global.contains("Global invalidation detected"));
     assert!(global.contains("cause-type global"));
-    assert!(global.contains(r#"<div class="global-banner""#));
+    assert!(global.contains(r#"<section class="global-banner""#));
     assert!(global.contains(r#"id="domino-meta""#));
 
-    // Non-global runs MUST remain visually identical to today's report —
-    // no banner element, no new pill, no collapsed group element. (The CSS
-    // *classes* are still emitted in the always-included <style> block; we
-    // assert on the rendered elements, not the stylesheet.)
+    // Non-global runs MUST remain visually identical when no global rule
+    // fired — no banner element, no new pill, no collapsed group element.
+    // (The CSS *classes* are still emitted in the always-included <style>
+    // block; we assert on the rendered elements, not the stylesheet.)
     assert!(!normal.contains("Global invalidation detected"));
     assert!(!normal.contains("\"cause-type global\""));
-    assert!(!normal.contains(r#"<div class="global-banner""#));
+    assert!(!normal.contains(r#"<section class="global-banner""#));
     assert!(!normal.contains(r#"<details class="global-only-group""#));
     // The metadata script is harmless on non-global runs and lets dashboards
     // pick up the same shape regardless of run type.
@@ -1604,6 +2231,108 @@ mod tests {
       nearby.contains("cause-type global"),
       "expected `cause-type global` near the pill, got: {}",
       nearby
+    );
+  }
+
+  #[test]
+  fn favicon_is_embedded_inline() {
+    // The report is a single-file artifact (saved, mailed, archived) — the
+    // favicon must be self-contained, not a relative URL that 404s.
+    let html = generate_html(&synth_normal_report());
+    assert!(
+      html.contains(r#"<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,"#),
+      "favicon must be an inline SVG data URI"
+    );
+    // `#` is the URI fragment separator; if any unencoded `#` slipped
+    // through the helper, the browser would truncate the data URI at the
+    // first color hex (e.g. #F26F0D in the logo) and the favicon would
+    // render as a broken image. Guard against that regression.
+    assert!(
+      !html.contains(r#"href="data:image/svg+xml,<svg"#),
+      "favicon data URI must url-encode `<`, otherwise some browsers/validators reject it"
+    );
+  }
+
+  #[test]
+  fn url_encode_svg_escapes_hash() {
+    let svg = r##"<svg fill="#F26F0D"/>"##;
+    let encoded = url_encode_svg(svg);
+    assert!(!encoded.contains('#'), "raw # must be percent-encoded");
+    assert!(encoded.contains("%23F26F0D"));
+    assert!(!encoded.contains('<'));
+    assert!(encoded.contains("%3Csvg"));
+  }
+
+  #[test]
+  fn top_bar_renders_logo_and_github_link() {
+    // Every report must carry brand identity + a path back to the project.
+    let html = generate_html(&synth_normal_report());
+    assert!(
+      html.contains(r#"id="domino-logo""#),
+      "inline domino logo must be present in the top bar"
+    );
+    assert!(
+      html.contains("https://github.com/frontops-dev/domino"),
+      "top bar must link back to the GitHub repository"
+    );
+    assert!(html.contains(r#"<header class="topbar""#));
+    assert!(
+      html.contains("Star on GitHub"),
+      "GitHub link must carry an accessible label"
+    );
+  }
+
+  #[test]
+  fn footer_links_to_repo_issues_and_license() {
+    let html = generate_html(&synth_normal_report());
+    assert!(html.contains("https://github.com/frontops-dev/domino/issues"));
+    assert!(html.contains("https://github.com/frontops-dev/domino/blob/main/LICENSE"));
+  }
+
+  #[test]
+  fn direct_change_carries_brand_accent_pill() {
+    // Encodes intent: the orange brand accent is scarce — only DirectChange
+    // (the strongest signal) wears it. Other cause variants get the desaturated
+    // semantic palette.
+    let html = generate_html(&synth_normal_report());
+    let direct = html
+      .find("Direct Change")
+      .expect("expected a Direct Change pill");
+    let nearby = &html[direct.saturating_sub(80)..direct];
+    assert!(
+      nearby.contains("cause-type direct"),
+      "Direct Change must use the orange-accent .direct pill class, got: {}",
+      nearby
+    );
+    // ImportedSymbol must NOT borrow the direct class.
+    let imported = html
+      .find("Imported Symbol")
+      .expect("expected an Imported Symbol pill");
+    let near_imported = &html[imported.saturating_sub(80)..imported];
+    assert!(!near_imported.contains("cause-type direct"));
+  }
+
+  #[test]
+  fn relative_time_helper_buckets() {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .unwrap()
+      .as_secs() as i64;
+
+    assert_eq!(format_relative_time(now), "just now");
+    assert_eq!(format_relative_time(now - 30), "just now");
+    assert_eq!(format_relative_time(now - 60 * 5), "5 minutes ago");
+    assert_eq!(format_relative_time(now - 60 * 60 * 3), "3 hours ago");
+    assert_eq!(format_relative_time(now - 60 * 60 * 26), "yesterday");
+    assert_eq!(format_relative_time(now - 60 * 60 * 24 * 3), "3 days ago");
+    // >7 days falls back to a raw timestamp form — assert that we don't lie
+    // by emitting a relative-time string with the wrong magnitude.
+    let old = format_relative_time(now - 60 * 60 * 24 * 30);
+    assert!(
+      old.contains("(run timestamp)"),
+      "expected fallback form for >7d-old runs, got: {}",
+      old
     );
   }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -165,9 +165,49 @@ pub struct AffectedResult {
 
 /// Detailed report of affected projects with causality information
 #[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AffectedReport {
   /// Information about each affected project
   pub projects: Vec<AffectedProjectInfo>,
+  /// Changed files that triggered Nx `namedInputs` global invalidation.
+  /// Empty for non-global runs.
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub global_triggers: Vec<GlobalTrigger>,
+  /// Aggregate counts for at-a-glance interpretation of the run.
+  pub totals: ReportTotals,
+  /// domino crate version that produced this report.
+  pub version: &'static str,
+  /// When the run started (seconds since Unix epoch). Integer chosen over
+  /// ISO-8601 to avoid pulling in a new date-time dependency just for this.
+  pub run_started_at_unix_secs: i64,
+}
+
+/// A changed file that matched a `{workspaceRoot}/...` pattern in nx.json's
+/// `namedInputs`, triggering global invalidation.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GlobalTrigger {
+  /// File that matched (relative to workspace root).
+  pub file: PathBuf,
+  /// Name of the `namedInputs` entry whose pattern matched, e.g. `sharedGlobals`.
+  pub named_input: String,
+  /// Original pattern string from nx.json, e.g. `{workspaceRoot}/nx.json`.
+  pub raw_pattern: String,
+}
+
+/// Aggregate counts surfaced at the top of the HTML report.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReportTotals {
+  /// Projects affected purely via global invalidation.
+  pub globally_invalidated: usize,
+  /// Projects affected via real semantic analysis (DirectChange,
+  /// ImportedSymbol, AssetChange, LockfileChange, ...).
+  pub semantically_affected: usize,
+  /// Projects affected via both global and semantic causes.
+  pub overlap: usize,
+  /// Total number of files changed in the diff (pre-filtering).
+  pub changed_files: usize,
 }
 
 /// Information about why a project is affected
@@ -245,6 +285,9 @@ pub enum AffectCause {
   GlobalInvalidation {
     /// The file that triggered global invalidation
     file: PathBuf,
+    /// The `namedInputs` entry whose pattern matched (e.g. `sharedGlobals`).
+    /// Surfaced in the report so the user recognizes the term from their nx.json.
+    named_input: String,
   },
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3495,7 +3495,7 @@ fn test_global_invalidation_html_report_contains_banner_and_metadata() {
     "banner heading missing"
   );
   assert!(
-    html.contains(r#"<div class="global-banner""#),
+    html.contains(r#"<section class="global-banner""#),
     "banner element missing"
   );
   assert!(
@@ -3525,7 +3525,7 @@ fn test_non_global_run_does_not_emit_new_global_markers() {
   let html = repo.get_html_report();
 
   assert!(!html.contains("Global invalidation detected"));
-  assert!(!html.contains(r#"<div class="global-banner""#));
+  assert!(!html.contains(r#"<section class="global-banner""#));
   assert!(!html.contains(r#"<span class="cause-type global">"#));
   assert!(!html.contains(r#"<details class="global-only-group""#));
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,6 @@
-use domino::core::find_affected;
+use domino::core::{find_affected, find_affected_with_report};
 use domino::profiler::Profiler;
+use domino::report::generate_html_report;
 use domino::types::{LockfileStrategy, Project, TrueAffectedConfig};
 use std::fs;
 use std::path::PathBuf;
@@ -3247,6 +3248,29 @@ impl TempNxRepo {
       .expect("find_affected failed")
       .affected_projects
   }
+
+  fn get_html_report(&self) -> String {
+    let projects = domino::workspace::discover_projects(self.root()).unwrap();
+    let config = TrueAffectedConfig {
+      cwd: self.root().to_path_buf(),
+      base: "main".to_string(),
+      head: None,
+      root_ts_config: None,
+      projects,
+      include: vec![],
+      ignored_paths: vec![],
+      lockfile_strategy: LockfileStrategy::None,
+    };
+
+    let profiler = Arc::new(Profiler::new(false));
+    let result =
+      find_affected_with_report(config, profiler).expect("find_affected_with_report failed");
+    let report = result
+      .report
+      .expect("expected a report when --report is on");
+    let out = self.root().join("report.html");
+    generate_html_report(&report, &out).expect("generate_html_report failed")
+  }
 }
 
 #[test]
@@ -3446,6 +3470,64 @@ fn test_named_inputs_negation_with_root_differs_from_source_root() {
     "lib-a should NOT be affected (.figma.tsx matched by negation pattern against project root). Got: {:?}",
     affected
   );
+}
+
+#[test]
+fn test_global_invalidation_html_report_contains_banner_and_metadata() {
+  // End-to-end check: a real global-invalidation run produces an HTML
+  // report that (1) opens with a self-explaining banner, (2) emits a
+  // structured JSON metadata block, (3) tags the cause pill with the new
+  // `cause-type global` class — not the misleading `direct` class.
+  let repo = TempNxRepo::new(
+    r#"{
+      "namedInputs": {
+        "default": ["{projectRoot}/**/*", "sharedGlobals"],
+        "sharedGlobals": ["{workspaceRoot}/babel.config.json"]
+      }
+    }"#,
+  );
+  repo.change_and_commit("babel.config.json", r#"{"presets": []}"#);
+
+  let html = repo.get_html_report();
+
+  assert!(
+    html.contains("Global invalidation detected"),
+    "banner heading missing"
+  );
+  assert!(
+    html.contains(r#"<div class="global-banner""#),
+    "banner element missing"
+  );
+  assert!(
+    html.contains(r#"<script type="application/json" id="domino-meta">"#),
+    "structured metadata block missing"
+  );
+  assert!(
+    html.contains("\"namedInput\":\"sharedGlobals\""),
+    "metadata should attribute the trigger to its sharedGlobals namedInput"
+  );
+  // The per-project pill must use the new `global` class, not `direct` —
+  // this is the regression guard for the original UX bug.
+  assert!(
+    html.contains(r#"<span class="cause-type global">Global Invalidation</span>"#),
+    "Global Invalidation pill must use the new `cause-type global` class"
+  );
+}
+
+#[test]
+fn test_non_global_run_does_not_emit_new_global_markers() {
+  // Additive guarantee: a normal (non-global) run must look identical to
+  // today's report — no banner element, no `cause-type global` pill, no
+  // collapsed group at the bottom.
+  let repo = TempNxRepo::new(r#"{}"#);
+  repo.change_and_commit("libs/lib-a/src/index.ts", "export const a = 99;\n");
+
+  let html = repo.get_html_report();
+
+  assert!(!html.contains("Global invalidation detected"));
+  assert!(!html.contains(r#"<div class="global-banner""#));
+  assert!(!html.contains(r#"<span class="cause-type global">"#));
+  assert!(!html.contains(r#"<details class="global-only-group""#));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **Self-explaining global-invalidation reports.** A top-of-page banner lists every changed file that matched an Nx `namedInputs` global pattern with its named-input attribution (e.g. `ci.yml ← matched sharedGlobals`). Globally-invalidated-only projects collapse into a single `<details>` at the bottom so semantic signal isn't drowned out. Summary stats split *Globally Invalidated* vs *Semantically Affected*.
- **Structured run metadata** embedded as `<script type=\"application/json\" id=\"domino-meta\">` for downstream consumers (CI dashboards, scrapers) — no HTML parsing required.
- **Visual revamp** carrying domino's brand identity: inline logo + favicon, *Star on GitHub* link, IBM Plex typography, brand-orange `#F26F0D` reserved for high-signal causes, restructured page flow (hero → stats → banner).

## Why

The HTML report didn't distinguish global-invalidation from real semantic signal — a workflow file change that swept 600 projects rendered as 600 identical \"Direct Change\"-styled cards with no top-level explanation. It also had no domino identity or path back to the repo, so a user opening the artifact cold had no anchor.

## What changed under the hood

- \`check_global_invalidation\` returns *every* matching trigger (was: first only). \`ResolvedNamedInputs.global_patterns\` retains the originating named-input name so the report shows the term the user wrote in nx.json.
- \`AffectCause::GlobalInvalidation\` carries \`named_input\`; \`AffectedReport\` carries \`global_triggers\`, \`totals\`, \`version\`, \`run_started_at_unix_secs\`.
- When \`--report\` is on, \`find_affected_internal\` no longer short-circuits on global invalidation — it runs full semantic analysis so the report can separate global from semantic affected projects. Non-report runs still take the fast path.
- \`generate_cytoscape_data\` defensively skips edges whose source/target isn't a node, so a cause that references an upstream lib outside the affected set doesn't crash cytoscape.

## Test plan

- [x] \`cargo test --lib\` — 206 unit tests pass.
- [x] \`cargo test --test integration_test --no-default-features 'named_inputs|global_invalidation_html|non_global_run' -- --test-threads=1\` — 9 tests pass.
- [x] \`cargo clippy --all-targets --all-features\` — clean.
- [x] \`cargo fmt --check\` — clean.


## Before 
<img width="800" height="845" alt="image" src="https://github.com/user-attachments/assets/33ad44d7-acbd-4204-b78e-e256d6aecb16" />

## After
<img width="1902" height="929" alt="image" src="https://github.com/user-attachments/assets/2010c7f3-a0c6-4691-8000-37b54ce0856f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reports now distinguish between global-level changes and specific file changes affecting projects
  * Enhanced attribution showing which configuration patterns triggered changes
  * Improved HTML report with redesigned layout, better styling, and project filtering controls
  * Added run timing metadata to reports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->