### PR TITLE
fix(git): anchor deletion-only hunks so dependents of deleted symbols are detected

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -191,9 +191,9 @@ fn parse_diff(diff: &str) -> Result<Vec<ChangedFile>> {
       // expand to every line in the new-side range `Z..Z+W`, so symbols that
       // live mid-hunk (not just at the hunk's starting line) are visible to
       // downstream AST lookups. When `,W` is omitted, git's convention is a
-      // single-line hunk (count = 1). Pure deletion hunks (`W == 0`) produce
-      // an empty range — see the `has_hunks` branch below for how those are
-      // preserved.
+      // single-line hunk (count = 1). Pure deletion hunks (`W == 0`) have no
+      // new-side lines, so they anchor to line `Z` (the line just before the
+      // deletion) — see the `count == 0` branch below.
       let ranges: Vec<std::ops::Range<usize>> = line_regex
         .captures_iter(file_diff)
         .filter_map(|caps| {
@@ -211,6 +211,18 @@ fn parse_diff(diff: &str) -> Result<Vec<ChangedFile>> {
                 .ok()
             })
             .unwrap_or(1);
+          if count == 0 {
+            // Deletion-only hunk (`+Z,0`). The removed lines are gone from the
+            // new file, but whatever top-level symbol *enclosed* them (e.g. an
+            // exported object losing a property, a switch losing a case) is still
+            // changed, and its dependents are affected. Anchor to the new-side
+            // line `Z` — the line just before the deletion point, still inside
+            // the enclosing symbol — so the downstream AST lookup can resolve
+            // that symbol and trace its references. Clamp to 1 for deletions at
+            // the top of the file (git emits `+0,0`).
+            let anchor = start.max(1);
+            return Some(anchor..anchor + 1);
+          }
           Some(start..start + count)
         })
         .collect();
@@ -522,12 +534,12 @@ index 1234567..abcdefg 100644
     assert_eq!(result[0].changed_lines, vec![1]);
   }
 
-  /// A pure-deletion hunk (`+Z,0`) has no new-side lines to scan and must
-  /// contribute zero entries to `changed_lines`. Pair it with a normal hunk
-  /// so the file-skip branch (which triggers on a fully empty result) is not
-  /// what's actually being tested.
+  /// A deletion hunk (`+Z,0`) anchors to its new-side line `Z` so the enclosing
+  /// symbol stays traceable, even when paired with a normal addition hunk. Here
+  /// the deletion at `+5,0` contributes anchor line 5, alongside the addition
+  /// hunk's lines 21 and 22.
   #[test]
-  fn test_parse_diff_pure_deletion_hunk_contributes_zero() {
+  fn test_parse_diff_deletion_hunk_anchors_alongside_addition() {
     let diff = r#"diff --git a/src/foo.ts b/src/foo.ts
 index 1234567..abcdefg 100644
 --- a/src/foo.ts
@@ -543,17 +555,17 @@ index 1234567..abcdefg 100644
 
     let result = parse_diff(diff).unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].changed_lines, vec![21, 22]);
+    assert_eq!(result[0].changed_lines, vec![5, 21, 22]);
   }
 
-  /// A file whose only hunks are deletions (`+Z,0`) must still be kept in
-  /// the result with an empty `changed_lines`. Dropping it would hide real
-  /// source changes — deleting an exported symbol is a meaningful change
-  /// even though there are no new-file lines to AST-lookup. Downstream in
-  /// `core.rs`, the file's owning package is still marked affected because
-  /// the file path is present.
+  /// A file whose only hunks are deletions (`+Z,0`) is kept in the result and
+  /// anchors to the new-side line of each deletion (line `Z`), so the symbol
+  /// that enclosed the removed lines — and therefore the deleted symbol's
+  /// dependents — can be traced downstream. Previously such files were kept with
+  /// an empty `changed_lines`, which left the file's owning package marked but
+  /// caused the reference cascade to be skipped, under-reporting dependents.
   #[test]
-  fn test_parse_diff_deletion_only_file_kept_with_empty_lines() {
+  fn test_parse_diff_deletion_only_file_anchors_to_enclosing_symbol_line() {
     let diff = r#"diff --git a/src/foo.ts b/src/foo.ts
 index 1234567..abcdefg 100644
 --- a/src/foo.ts
@@ -567,7 +579,7 @@ index 1234567..abcdefg 100644
     let result = parse_diff(diff).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].file_path.to_str().unwrap(), "src/foo.ts");
-    assert!(result[0].changed_lines.is_empty());
+    assert_eq!(result[0].changed_lines, vec![5]);
   }
 
   /// Symmetric hunk header — old and new sides both carry a count. Common in
@@ -593,5 +605,33 @@ index 1234567..abcdefg 100644
     let result = parse_diff(diff).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].changed_lines, vec![3, 4, 5]);
+  }
+
+  /// Regression for the deletion-only under-detection bug.
+  ///
+  /// `git diff --unified=0` emits a `+Z,0` hunk when a line is removed. The
+  /// removed content no longer exists in the new file, but the *enclosing*
+  /// top-level symbol (here the exported `declarativeCalculations` object) is
+  /// still meaningfully changed, and every project that consumes that symbol is
+  /// affected. To trace them, the deletion must anchor to the new-side line `Z`
+  /// — the line immediately before the deletion point, which is still inside the
+  /// enclosing symbol — so the downstream AST lookup can resolve the symbol.
+  ///
+  /// Before the fix, deletion hunks contributed nothing to `changed_lines`, so
+  /// symbol extraction found nothing and the reference cascade was skipped,
+  /// under-reporting the deleted symbol's dependents.
+  #[test]
+  fn test_parse_diff_deletion_only_hunk_anchors_to_new_side_line() {
+    let diff = r#"diff --git a/src/attrs.ts b/src/attrs.ts
+index 1234567..abcdefg 100644
+--- a/src/attrs.ts
++++ b/src/attrs.ts
+@@ -495 +494,0 @@ export const declarativeCalculations = {
+-  'Commissions & Fees': { alternative: ['Bank Charges'] },
+"#;
+
+    let result = parse_diff(diff).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].changed_lines, vec![494]);
   }
 }


### PR DESCRIPTION
Closes #74.

## Summary

`parse_diff` in `src/git.rs` expands each diff hunk header to the new-side range `start..start + count`. With `--unified=0` (which `get_diff` always uses, `src/git.rs:111`), removing a line produces a `@@ -X,Y +Z,0 @@` hunk — new-side count `W == 0` — so `start..start + count` is the empty range `Z..Z` and the deletion contributes nothing to `changed_lines`. Downstream in `src/core.rs`, an empty `changed_lines` yields no symbols, `unique_symbols` is empty, and reference traversal is skipped (`No traceable symbols found … skipping reference traversal`). The file's owning package is still marked, but every project that depends on the deleted symbol is silently dropped.

This is the deletion-only counterpart of #62. #63 expanded `changed_lines` to the full hunk range, fixing the addition / multi-line case, but a `W == 0` deletion still expands to an empty range — #63 codified that in `test_parse_diff_pure_deletion_hunk_contributes_zero`. This PR closes that remaining gap (direction (1) from #74).

## Change

`src/git.rs`, in the `parse_diff` hunk-range loop — anchor a `W == 0` deletion hunk to its new-side line `Z` instead of emitting an empty range:

```rust
let count: usize = caps
    .get(2)
    .and_then(|m| m.as_str().parse().ok())
    .unwrap_or(1);
if count == 0 {
    // Deletion-only hunk (`+Z,0`). The removed lines are gone from the new
    // file, but the top-level symbol that *enclosed* them (e.g. an exported
    // object losing a property, a switch losing a case) is still changed, and
    // its dependents are affected. Anchor to the new-side line `Z` — the line
    // just before the deletion point, still inside the enclosing symbol — so
    // the downstream AST lookup can resolve that symbol and trace its refs.
    // Clamp to 1 for deletions at the top of the file (git emits `+0,0`).
    let anchor = start.max(1);
    return Some(anchor..anchor + 1);
}
Some(start..start + count)
```

`Z` is the line immediately before the deletion point, which is still inside the enclosing top-level symbol, so `find_node_at_line(Z)` resolves it (e.g. `TABLE`) and the existing cascade traces its consumers.

## Tests

- **`test_parse_diff_deletion_only_hunk_anchors_to_new_side_line`** (new) — regression mirroring the real hunk `@@ -495 +494,0 @@`; asserts `changed_lines == [494]`.
- **`test_parse_diff_deletion_hunk_anchors_alongside_addition`** (was `test_parse_diff_pure_deletion_hunk_contributes_zero`, added in #63) — the deletion at `+5,0` now anchors line 5 alongside the addition hunk's lines: `[5, 21, 22]` (was `[21, 22]`).
- **`test_parse_diff_deletion_only_file_anchors_to_enclosing_symbol_line`** (was `..._kept_with_empty_lines`) — a deletion-only file now yields `[5]` instead of an empty `changed_lines`.

Both renamed tests had encoded the "deletion contributes nothing" behavior this PR corrects.

`cargo test --lib` — 208 passed, 0 failed. `cargo fmt --check` and `cargo clippy --lib` clean.

## Caller impact

Reviewed every read of `ChangedFile.changed_lines`:

- `core.rs:208-223` — each line is mapped to a symbol via `find_node_at_line`, then deduplicated into `unique_symbols`. The new anchor line resolves to the enclosing symbol; if a deletion ever anchors to a line outside any declaration it contributes an empty `Vec<String>` and does nothing — i.e. no worse than today. No behavioural change except the bug is fixed.
- `core.rs:194-201, 235-257` — `AffectCause::DirectChange { line }` reporting now records one cause for the anchor line of a deletion (previously zero). A correctness improvement; previously under-reported.
- `lockfile.rs` — reads only `file_path`, never `changed_lines`.

No change to `ChangedFile`, no new public API.

## Manual validation

Two-package Rush fixture (anonymized; same shape as #74's repro), `package-b` calls `lookup()` from `package-a`, which reads an exported `TABLE` object:

| Branch | Before (`@1.4.0`) | After (fix) |
|---|---|---|
| `edit` (in-place body change) | `[package-a, package-b]` | `[package-a, package-b]` |
| `delete` (remove one `TABLE` entry) | `[package-a]` ❌ | `[package-a, package-b]` ✅ |

The `edit` control confirms the cascade itself works; only the `delete` shape regressed, and the fix restores it. Also validated on a real Rush monorepo: a one-line deletion from an exported lookup object consumed by ~26 projects went from **1** affected project to **22** (the projects that actually reference it — the semantic cascade stays precise, it's just no longer short-circuited).

## Out of scope

Direction (2) from #74 — recovering a deleted *entire* top-level symbol by parsing the base revision at the old-side range — is deferred. When a deletion removes a whole symbol, the anchor line falls outside any declaration and behaviour falls back to today's package-level marking (no regression, just not improved).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection and tracking of deleted content. The system now properly processes deletions during change analysis, ensuring all removed code is accurately captured and identified for downstream symbol and reference detection. Updated regression tests verify correct deletion handling at both file and change level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->