### PR TITLE
fix(semantic): recognize .mts/.mjs/.cts/.cjs as source files

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -172,8 +172,9 @@ fn find_affected_internal(
   for changed_file in &source_files {
     let file_path = &changed_file.file_path;
 
-    // Check if file exists in our analyzed files. A source-typed file (.ts/.tsx/.js/.jsx)
-    // can live inside a project's root but outside its sourceRoot (e.g. jest.config.js,
+    // Check if file exists in our analyzed files. A source-typed file
+    // (.ts/.tsx/.js/.jsx/.mts/.mjs/.cts/.cjs) can live inside a project's root
+    // but outside its sourceRoot (e.g. jest.config.js,
     // webpack.config.js at project root when sourceRoot = "<proj>/src"). The semantic
     // analyzer only walks sourceRoot, so such files never reach it — but they still
     // belong to the project and changing them must mark it affected. Fall back to the

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -244,7 +244,12 @@ impl WorkspaceAnalyzer {
             .path()
             .extension()
             .and_then(|ext| ext.to_str())
-            .is_some_and(|ext| matches!(ext, "ts" | "tsx" | "js" | "jsx"))
+            .is_some_and(|ext| {
+              matches!(
+                ext,
+                "ts" | "tsx" | "js" | "jsx" | "mts" | "mjs" | "cts" | "cjs"
+              )
+            })
       })
       .map(|e| {
         let abs_path = e.into_path();

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -238,19 +238,9 @@ impl WorkspaceAnalyzer {
         e.map_err(|err| warn!("Failed to read directory entry: {}", err))
           .ok()
       })
-      .filter(|e| {
-        e.file_type().is_file()
-          && e
-            .path()
-            .extension()
-            .and_then(|ext| ext.to_str())
-            .is_some_and(|ext| {
-              matches!(
-                ext,
-                "ts" | "tsx" | "js" | "jsx" | "mts" | "mjs" | "cts" | "cjs"
-              )
-            })
-      })
+      // Reuse the shared source-file predicate (single source of truth for the
+      // extension set) so the walk can't drift from `SOURCE_EXTENSIONS`.
+      .filter(|e| e.file_type().is_file() && crate::utils::is_source_file(e.path()))
       .map(|e| {
         let abs_path = e.into_path();
         let rel_path = abs_path

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -13,7 +13,8 @@ pub(crate) use resolve_options::is_workspace_specifier;
 pub(crate) use resolve_options::parse_tsconfig_path_prefixes;
 
 /// Shared fallback resolution for relative imports when oxc_resolver fails.
-/// Handles .js/.jsx → .ts/.tsx remapping and standard extension probing.
+/// Handles .js/.jsx/.mjs/.cjs → .ts/.tsx/.mts/.cts remapping and standard
+/// extension probing.
 pub(crate) fn simple_resolve_relative(
   cwd: &Path,
   context: &Path,
@@ -31,24 +32,27 @@ pub(crate) fn simple_resolve_relative(
     }
   };
 
-  // 1. .js/.jsx → .ts/.tsx remapping (ESM convention)
-  if let Some(stem) = specifier.strip_suffix(".js") {
-    let stem_path = context.join(stem);
-    let stem_str = stem_path.to_string_lossy();
-    for ext in &[".ts", ".tsx", ".js"] {
-      let candidate = PathBuf::from(format!("{}{}", stem_str, ext));
-      if let Some(p) = try_candidate(&candidate) {
-        return Some(p);
+  // 1. .js/.jsx/.mjs/.cjs → .ts/.tsx/.mts/.cts remapping (ESM convention).
+  // TypeScript ESM emits `.mjs` specifiers for `.mts` sources (and `.cjs` for
+  // `.cts`), so a barrel doing `export * from "./foo.mjs"` must resolve to
+  // `foo.mts`.
+  let ext_remap: &[(&str, &[&str])] = &[
+    (".js", &[".ts", ".tsx", ".js"]),
+    (".jsx", &[".tsx", ".jsx"]),
+    (".mjs", &[".mts", ".mjs"]),
+    (".cjs", &[".cts", ".cjs"]),
+  ];
+  for (suffix, candidates) in ext_remap {
+    if let Some(stem) = specifier.strip_suffix(suffix) {
+      let stem_path = context.join(stem);
+      let stem_str = stem_path.to_string_lossy();
+      for ext in *candidates {
+        let candidate = PathBuf::from(format!("{}{}", stem_str, ext));
+        if let Some(p) = try_candidate(&candidate) {
+          return Some(p);
+        }
       }
-    }
-  } else if let Some(stem) = specifier.strip_suffix(".jsx") {
-    let stem_path = context.join(stem);
-    let stem_str = stem_path.to_string_lossy();
-    for ext in &[".tsx", ".jsx"] {
-      let candidate = PathBuf::from(format!("{}{}", stem_str, ext));
-      if let Some(p) = try_candidate(&candidate) {
-        return Some(p);
-      }
+      break;
     }
   }
 
@@ -60,10 +64,18 @@ pub(crate) fn simple_resolve_relative(
     ".tsx",
     ".js",
     ".jsx",
+    ".mts",
+    ".mjs",
+    ".cts",
+    ".cjs",
     "/index.ts",
     "/index.tsx",
     "/index.js",
     "/index.jsx",
+    "/index.mts",
+    "/index.mjs",
+    "/index.cts",
+    "/index.cjs",
   ] {
     let candidate = if let Some(stripped) = suffix.strip_prefix('/') {
       base.join(stripped)

--- a/src/semantic/reference_finder.rs
+++ b/src/semantic/reference_finder.rs
@@ -558,6 +558,30 @@ mod tests {
   }
 
   #[test]
+  fn test_simple_resolve_cjs_to_cts_remapping() {
+    // CommonJS TS counterpart: .cjs specifiers resolve to .cts sources.
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let cwd = temp_dir.path();
+
+    let src_dir = cwd.join("src");
+    fs::create_dir_all(&src_dir).expect("Failed to create src dir");
+    fs::write(src_dir.join("legacy.cts"), "export const schema = 1;")
+      .expect("Failed to write test file");
+
+    let profiler = Arc::new(Profiler::new(false));
+    let analyzer =
+      WorkspaceAnalyzer::new(vec![], cwd, profiler.clone()).expect("Failed to create analyzer");
+    let reference_finder = ReferenceFinder::new(&analyzer, cwd, profiler);
+
+    let resolved = reference_finder.simple_resolve(src_dir.as_path(), "./legacy.cjs");
+    assert_eq!(
+      resolved,
+      Some(PathBuf::from("src/legacy.cts")),
+      "Expected ./legacy.cjs to resolve to legacy.cts"
+    );
+  }
+
+  #[test]
   fn test_simple_resolve_index_mts() {
     // A bare directory specifier should find index.mts (ESM package entry).
     let temp_dir = TempDir::new().expect("Failed to create temp dir");

--- a/src/semantic/reference_finder.rs
+++ b/src/semantic/reference_finder.rs
@@ -533,6 +533,55 @@ mod tests {
   }
 
   #[test]
+  fn test_simple_resolve_mjs_to_mts_remapping() {
+    // TypeScript ESM emits .mjs specifiers for .mts sources, e.g.
+    // `export * from './contract.mjs'` where the actual file is contract.mts.
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let cwd = temp_dir.path();
+
+    let src_dir = cwd.join("src");
+    fs::create_dir_all(&src_dir).expect("Failed to create src dir");
+    fs::write(src_dir.join("contract.mts"), "export const schema = 1;")
+      .expect("Failed to write test file");
+
+    let profiler = Arc::new(Profiler::new(false));
+    let analyzer =
+      WorkspaceAnalyzer::new(vec![], cwd, profiler.clone()).expect("Failed to create analyzer");
+    let reference_finder = ReferenceFinder::new(&analyzer, cwd, profiler);
+
+    let resolved = reference_finder.simple_resolve(src_dir.as_path(), "./contract.mjs");
+    assert_eq!(
+      resolved,
+      Some(PathBuf::from("src/contract.mts")),
+      "Expected ./contract.mjs to resolve to contract.mts"
+    );
+  }
+
+  #[test]
+  fn test_simple_resolve_index_mts() {
+    // A bare directory specifier should find index.mts (ESM package entry).
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let cwd = temp_dir.path();
+
+    let pkg_src = cwd.join("packages").join("contract").join("src");
+    fs::create_dir_all(&pkg_src).expect("Failed to create pkg dir");
+    fs::write(pkg_src.join("index.mts"), "export const x = 1;").expect("Failed to write test file");
+
+    let profiler = Arc::new(Profiler::new(false));
+    let analyzer =
+      WorkspaceAnalyzer::new(vec![], cwd, profiler.clone()).expect("Failed to create analyzer");
+    let reference_finder = ReferenceFinder::new(&analyzer, cwd, profiler);
+
+    let context = cwd.join("packages").join("contract");
+    let resolved = reference_finder.simple_resolve(context.as_path(), "./src");
+    assert_eq!(
+      resolved,
+      Some(PathBuf::from("packages/contract/src/index.mts")),
+      "Expected ./src to resolve to src/index.mts"
+    );
+  }
+
+  #[test]
   fn test_simple_resolve_js_to_tsx_remapping() {
     // Test that .js imports can resolve to .tsx files
 

--- a/src/semantic/resolve_options.rs
+++ b/src/semantic/resolve_options.rs
@@ -68,17 +68,26 @@ pub fn create_resolve_options(cwd: &Path, projects: &[Project]) -> ResolveOption
       ".tsx".into(),
       ".js".into(),
       ".jsx".into(),
+      ".mts".into(),
+      ".mjs".into(),
+      ".cts".into(),
+      ".cjs".into(),
       ".d.ts".into(),
+      ".d.mts".into(),
+      ".d.cts".into(),
     ],
-    // Map .js/.jsx imports to their TypeScript equivalents.
-    // Handles the common ESM pattern where .ts files import with .js extensions
-    // (e.g., import { foo } from './bar.js' where the actual file is bar.ts).
+    // Map .js/.jsx/.mjs/.cjs imports to their TypeScript equivalents.
+    // Handles the ESM pattern where TS files import with runtime extensions
+    // (e.g. `import { foo } from './bar.js'` where the source is bar.ts, or
+    // `'./bar.mjs'` where the source is bar.mts).
     extension_alias: vec![
       (
         ".js".into(),
         vec![".ts".into(), ".tsx".into(), ".js".into()],
       ),
       (".jsx".into(), vec![".tsx".into(), ".jsx".into()]),
+      (".mjs".into(), vec![".mts".into(), ".mjs".into()]),
+      (".cjs".into(), vec![".cts".into(), ".cjs".into()]),
     ],
     // Resolve bare package imports to source roots within the monorepo.
     alias,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,8 +4,11 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::{Path, PathBuf};
 use tracing::debug;
 
-/// Extensions considered as source files (analyzed by Oxc parser)
-const SOURCE_EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx"];
+/// Extensions considered as source files (analyzed by Oxc parser).
+/// Includes the explicit ESM/CJS TypeScript & JavaScript extensions
+/// (`.mts`/`.mjs`/`.cts`/`.cjs`) — without these, files using them are
+/// misclassified as assets and skip semantic analysis entirely.
+const SOURCE_EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "mts", "mjs", "cts", "cjs"];
 
 /// Check if a file is a source file (TypeScript/JavaScript)
 /// These are files that can be parsed by the Oxc parser
@@ -230,6 +233,10 @@ mod tests {
     assert!(is_source_file(Path::new("utils.js")));
     assert!(is_source_file(Path::new("app.jsx")));
     assert!(is_source_file(Path::new("path/to/file.ts")));
+    assert!(is_source_file(Path::new("contract.mts")));
+    assert!(is_source_file(Path::new("worker.mjs")));
+    assert!(is_source_file(Path::new("legacy.cts")));
+    assert!(is_source_file(Path::new("legacy.cjs")));
 
     // Non-source files
     assert!(!is_source_file(Path::new("styles.css")));


### PR DESCRIPTION
## Problem

Files using the explicit ESM/CJS TypeScript & JavaScript extensions — `.mts`, `.mjs`, `.cts`, `.cjs` — are not recognized as source files. They are classified as **assets**, so they skip Oxc symbol analysis entirely. As a result, a change to any such file never propagates to the projects that import it: `affected` reports only the package that directly owns the changed file, silently missing every downstream consumer.

This is invisible in mixed repos — `.ts`/`.tsx` analysis keeps working — so the gap only shows up as under-reporting on the `.mts`-based parts of the graph. In a monorepo whose package entrypoints and cross-package contracts are `.mts` (e.g. modern NestJS services, native Node ESM packages), that's the entire cross-service dependency layer.

## Minimal repro

One package, one file, the *same* single-symbol change — only the extension differs:

| extension | `affected --debug` partition |
| --- | --- |
| `.ts` | `Partitioned files: 1 source, 0 assets` ✓ |
| `.tsx` | `1 source, 0 assets` ✓ |
| `.mts` | `0 source, **1 asset**` ✗ |
| `.mjs` | `0 source, **1 asset**` ✗ |
| `.cts` | `0 source, **1 asset**` ✗ |

With the changed file treated as an asset, the debug log shows `Found 0 references to asset "...index.mts"` and the consumers are never reached.

## Root cause

`SOURCE_EXTENSIONS` in `src/utils.rs` (which drives `is_source_file` → the source/asset partition) lists only `["ts", "tsx", "js", "jsx"]`. The same `ts | tsx | js | jsx` set is hardcoded in the sourceRoot directory walk and the resolver config.

This is the natural completion of #24, which added `.js`/`.jsx` → `.ts`/`.tsx` ESM import resolution but did not cover the `.mjs`/`.cjs` runtime-extension variants that TypeScript emits for `.mts`/`.cts` sources (`export * from "./foo.mjs"` where the source is `foo.mts`).

## Fix

- **`utils.rs`** — add `mts`/`mjs`/`cts`/`cjs` to `SOURCE_EXTENSIONS` (the source/asset partition)
- **`semantic/analyzer.rs`** — include them in the sourceRoot directory walk
- **`semantic/mod.rs`** — remap `.mjs`→`.mts` and `.cjs`→`.cts` in the relative resolver (TS ESM emits runtime extensions), and probe `.mts`/`.mjs`/`.cts` + `/index.mts` variants
- **`semantic/resolve_options.rs`** — add the extensions and the `.mjs`/`.cjs` `extension_alias` entries to the oxc resolver

## Tests

- New `is_source_file` assertions for `.mts`/`.mjs`/`.cts`/`.cjs`
- New resolver tests: `.mjs → .mts` remap and `/index.mts` directory-entry probing
- Full suite green: `209 passed; 0 failed`
- Verified end-to-end on a 250-package Nx 22 + pnpm production monorepo: changing a consumed symbol in a `.mts` temporal-contract now correctly marks the importing worker project as affected (previously missed), while projects importing *unchanged* symbols from the same package remain correctly pruned — i.e. precision is preserved, only the false negatives are fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded TypeScript/JavaScript file recognition to include `.mts`, `.mjs`, `.cts`, and `.cjs` files.
  * Improved module resolution so imports can find matching TypeScript variants and directory index files in more cases.

* **Bug Fixes**
  * Workspace analysis now includes modern ESM/CJS file variants, helping them appear in search, navigation, and related tooling.
  * Added coverage for resolving module-style imports and index files to reduce missed references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->