### PR TITLE
fix: exempt dependency manifests from sharedGlobals global invalidation

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -119,18 +119,22 @@ fn find_affected_internal(
     .as_ref()
     .is_some_and(|pm| lockfile::has_lockfile_changed(&changed_files, pm));
 
-  // A dependency update touches the lockfile and package.json together. When
-  // those are listed in `sharedGlobals` they would short-circuit to "all
-  // projects" before the lockfile analysis (Step 5c) runs, making it dead code.
-  // Exempt the lockfile (always) and package.json (only when the lockfile also
-  // changed, so the analysis has something to resolve) from global invalidation.
-  // A package.json-only change and any *other* global trigger (.nvmrc, nx.json,
-  // ...) still invalidate every project.
+  // Dependency manifests (the lockfile, and package.json when the lockfile also
+  // changed) are exempt from global invalidation so the lockfile analysis
+  // (Step 5c) computes the real affected set instead of short-circuiting to "all
+  // projects". The exemption is gated on that analysis actually running: under
+  // `LockfileStrategy::None` there is no Step 5c, so a manifest listed in
+  // `sharedGlobals` stays a global trigger rather than being silently dropped
+  // (which would flip all → 0 — the same under-inclusion the package.json guard
+  // prevents). Any *other* global trigger (.nvmrc, nx.json, ...) always
+  // invalidates every project.
+  let lockfile_analysis_enabled = !matches!(config.lockfile_strategy, LockfileStrategy::None);
   let global_triggers: Vec<GlobalTrigger> = if let Some(ref inputs) = resolved_inputs {
     named_inputs::check_global_invalidation(inputs, &changed_files)
       .into_iter()
       .filter(|t| {
-        !lockfile::is_dependency_manifest(&t.file, detected_pm.as_ref(), lockfile_changed)
+        !(lockfile_analysis_enabled
+          && lockfile::is_dependency_manifest(&t.file, detected_pm.as_ref(), lockfile_changed))
       })
       .collect()
   } else {

--- a/src/core.rs
+++ b/src/core.rs
@@ -581,7 +581,12 @@ fn find_affected_internal(
   // Step 5c: Process lockfile changes
   if !matches!(config.lockfile_strategy, LockfileStrategy::None) {
     if let Some(ref pm) = detected_pm {
-      if lockfile::has_lockfile_changed(&changed_files, pm) {
+      // Reuse the single `lockfile_changed` computed above rather than
+      // recomputing on the (post-negation) filtered set. This guarantees the
+      // exemption gate and the analysis agree on whether the lockfile changed —
+      // if they diverged, a lockfile could be dropped from global triggers yet
+      // skipped here, silently under-including (all -> 0).
+      if lockfile_changed {
         debug!("Lockfile changed, strategy: {:?}", config.lockfile_strategy);
         match lockfile::find_affected_dependencies(&config.cwd, &merge_base, pm) {
           Ok(affected_deps) if !affected_deps.is_empty() => {

--- a/src/core.rs
+++ b/src/core.rs
@@ -115,16 +115,23 @@ fn find_affected_internal(
   // exempted from global invalidation below.
   let detected_pm = lockfile::detect_package_manager(&config.cwd);
   let lockfile_filename = detected_pm.as_ref().map(|pm| lockfile::lockfile_name(pm));
+  let lockfile_changed = detected_pm
+    .as_ref()
+    .is_some_and(|pm| lockfile::has_lockfile_changed(&changed_files, pm));
 
   // A dependency update touches the lockfile and package.json together. When
   // those are listed in `sharedGlobals` they would short-circuit to "all
   // projects" before the lockfile analysis (Step 5c) runs, making it dead code.
-  // Exempt them so the lockfile + semantic pipeline computes the real affected
-  // set; any *other* global trigger (e.g. .nvmrc, nx.json) still invalidates all.
+  // Exempt the lockfile (always) and package.json (only when the lockfile also
+  // changed, so the analysis has something to resolve) from global invalidation.
+  // A package.json-only change and any *other* global trigger (.nvmrc, nx.json,
+  // ...) still invalidate every project.
   let global_triggers: Vec<GlobalTrigger> = if let Some(ref inputs) = resolved_inputs {
     named_inputs::check_global_invalidation(inputs, &changed_files)
       .into_iter()
-      .filter(|t| !lockfile::is_dependency_manifest(&t.file, detected_pm.as_ref()))
+      .filter(|t| {
+        !lockfile::is_dependency_manifest(&t.file, detected_pm.as_ref(), lockfile_changed)
+      })
       .collect()
   } else {
     Vec::new()
@@ -163,11 +170,9 @@ fn find_affected_internal(
   let mut affected_packages = FxHashSet::default();
   let mut project_causes: FxHashMap<String, Vec<AffectCause>> = FxHashMap::default();
 
-  // Step 5: Partition changed files into source and non-source (excluding
-  // lockfiles). `detected_pm` / `lockfile_filename` are computed above so the
+  // Step 6: Partition changed files into source and non-source (excluding the
+  // lockfile). `detected_pm` / `lockfile_filename` were computed above so the
   // dependency-manifest exemption and this partition share one detection.
-
-  // Step 6: Partition changed files into source and non-source
   let (source_files, asset_files): (Vec<&ChangedFile>, Vec<&ChangedFile>) = changed_files
     .iter()
     .filter(|f| {

--- a/src/core.rs
+++ b/src/core.rs
@@ -109,8 +109,23 @@ fn find_affected_internal(
   // a global run so the HTML can separate "globally invalidated" from
   // "semantically affected" projects — the whole point of the report.
   let resolved_inputs = named_inputs::resolve_from_nx_json(&config.cwd);
+
+  // Detect the package manager up front so dependency-manifest files (the
+  // package manager's lockfile and the workspace-root package.json) can be
+  // exempted from global invalidation below.
+  let detected_pm = lockfile::detect_package_manager(&config.cwd);
+  let lockfile_filename = detected_pm.as_ref().map(|pm| lockfile::lockfile_name(pm));
+
+  // A dependency update touches the lockfile and package.json together. When
+  // those are listed in `sharedGlobals` they would short-circuit to "all
+  // projects" before the lockfile analysis (Step 5c) runs, making it dead code.
+  // Exempt them so the lockfile + semantic pipeline computes the real affected
+  // set; any *other* global trigger (e.g. .nvmrc, nx.json) still invalidates all.
   let global_triggers: Vec<GlobalTrigger> = if let Some(ref inputs) = resolved_inputs {
     named_inputs::check_global_invalidation(inputs, &changed_files)
+      .into_iter()
+      .filter(|t| !lockfile::is_dependency_manifest(&t.file, detected_pm.as_ref()))
+      .collect()
   } else {
     Vec::new()
   };
@@ -148,9 +163,9 @@ fn find_affected_internal(
   let mut affected_packages = FxHashSet::default();
   let mut project_causes: FxHashMap<String, Vec<AffectCause>> = FxHashMap::default();
 
-  // Step 5: Partition changed files into source and non-source (excluding lockfiles)
-  let detected_pm = lockfile::detect_package_manager(&config.cwd);
-  let lockfile_filename = detected_pm.as_ref().map(|pm| lockfile::lockfile_name(pm));
+  // Step 5: Partition changed files into source and non-source (excluding
+  // lockfiles). `detected_pm` / `lockfile_filename` are computed above so the
+  // dependency-manifest exemption and this partition share one detection.
 
   // Step 6: Partition changed files into source and non-source
   let (source_files, asset_files): (Vec<&ChangedFile>, Vec<&ChangedFile>) = changed_files

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -96,6 +96,22 @@ pub fn has_lockfile_changed(changed_files: &[ChangedFile], pm: &PackageManager) 
     .any(|f| f.file_path.to_str() == Some(name))
 }
 
+/// Whether `file_path` (relative to the workspace root) is a dependency manifest
+/// handled by the lockfile/semantic pipeline rather than by global invalidation:
+/// the workspace-root `package.json` or the detected package manager's lockfile.
+///
+/// A dependency update touches both together, so both must be exempt from
+/// `sharedGlobals` global invalidation for the lockfile analysis in `core` to
+/// take effect — otherwise listing the lockfile in `sharedGlobals` short-circuits
+/// to "all projects" before that analysis ever runs, making it dead code.
+pub fn is_dependency_manifest(file_path: &Path, pm: Option<&PackageManager>) -> bool {
+  match file_path.to_str() {
+    Some("package.json") => true,
+    Some(name) => pm.map(|pm| name == lockfile_name(pm)).unwrap_or(false),
+    None => false,
+  }
+}
+
 /// Read a file at `file_path` from the given git revision.
 ///
 /// Returns `Ok(None)` when the object does not exist at the revision (e.g. new
@@ -2216,5 +2232,48 @@ lib-a@^1.0.0:
   fn test_extract_workspace_patterns_invalid_json() {
     let patterns = extract_workspace_patterns("not json");
     assert!(patterns.is_empty());
+  }
+
+  #[test]
+  fn test_is_dependency_manifest() {
+    use std::path::Path;
+
+    // package.json is always a dependency manifest, regardless of package manager.
+    assert!(is_dependency_manifest(Path::new("package.json"), None));
+    assert!(is_dependency_manifest(
+      Path::new("package.json"),
+      Some(&PackageManager::Pnpm)
+    ));
+
+    // The detected package manager's lockfile is a dependency manifest.
+    assert!(is_dependency_manifest(
+      Path::new("pnpm-lock.yaml"),
+      Some(&PackageManager::Pnpm)
+    ));
+    assert!(is_dependency_manifest(
+      Path::new("package-lock.json"),
+      Some(&PackageManager::Npm)
+    ));
+
+    // A lockfile for a *different* package manager than detected is not exempt.
+    assert!(!is_dependency_manifest(
+      Path::new("pnpm-lock.yaml"),
+      Some(&PackageManager::Npm)
+    ));
+    // Without a detected package manager, only package.json qualifies.
+    assert!(!is_dependency_manifest(Path::new("pnpm-lock.yaml"), None));
+
+    // Other workspace-root files (e.g. .nvmrc) are never dependency manifests,
+    // so they keep triggering global invalidation.
+    assert!(!is_dependency_manifest(
+      Path::new(".nvmrc"),
+      Some(&PackageManager::Pnpm)
+    ));
+    // Nested package.json is not the workspace-root manifest (never a global
+    // trigger anyway — those match {workspaceRoot}/ only).
+    assert!(!is_dependency_manifest(
+      Path::new("libs/foo/package.json"),
+      Some(&PackageManager::Pnpm)
+    ));
   }
 }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -97,19 +97,31 @@ pub fn has_lockfile_changed(changed_files: &[ChangedFile], pm: &PackageManager) 
 }
 
 /// Whether `file_path` (relative to the workspace root) is a dependency manifest
-/// handled by the lockfile/semantic pipeline rather than by global invalidation:
-/// the workspace-root `package.json` or the detected package manager's lockfile.
+/// that should be exempt from `sharedGlobals` global invalidation because the
+/// lockfile/semantic pipeline will analyze it instead. Without this, listing the
+/// lockfile in `sharedGlobals` short-circuits to "all projects" before that
+/// analysis ever runs (see `core`'s Step 1b), making it dead code.
 ///
-/// A dependency update touches both together, so both must be exempt from
-/// `sharedGlobals` global invalidation for the lockfile analysis in `core` to
-/// take effect — otherwise listing the lockfile in `sharedGlobals` short-circuits
-/// to "all projects" before that analysis ever runs, making it dead code.
-pub fn is_dependency_manifest(file_path: &Path, pm: Option<&PackageManager>) -> bool {
-  match file_path.to_str() {
-    Some("package.json") => true,
-    Some(name) => pm.map(|pm| name == lockfile_name(pm)).unwrap_or(false),
-    None => false,
+/// - The detected package manager's **lockfile** is always exempt — lockfile
+///   analysis owns it.
+/// - The workspace-root **`package.json`** is exempt only when the lockfile also
+///   changed (`lockfile_changed`). A dependency update touches both together, so
+///   lockfile analysis can resolve the affected importers. A `package.json`-only
+///   change (e.g. an uninstalled version-range edit, or a repo with no lockfile)
+///   has nothing to analyze, so it stays a global trigger rather than silently
+///   under-including.
+pub fn is_dependency_manifest(
+  file_path: &Path,
+  pm: Option<&PackageManager>,
+  lockfile_changed: bool,
+) -> bool {
+  let Some(name) = file_path.to_str() else {
+    return false;
+  };
+  if pm.is_some_and(|pm| name == lockfile_name(pm)) {
+    return true;
   }
+  name == "package.json" && lockfile_changed
 }
 
 /// Read a file at `file_path` from the given git revision.
@@ -2238,42 +2250,62 @@ lib-a@^1.0.0:
   fn test_is_dependency_manifest() {
     use std::path::Path;
 
-    // package.json is always a dependency manifest, regardless of package manager.
-    assert!(is_dependency_manifest(Path::new("package.json"), None));
-    assert!(is_dependency_manifest(
-      Path::new("package.json"),
-      Some(&PackageManager::Pnpm)
-    ));
-
-    // The detected package manager's lockfile is a dependency manifest.
+    // The detected package manager's lockfile is always exempt, regardless of
+    // whether `lockfile_changed` was computed true (the lockfile file being
+    // present in the diff is itself what makes lockfile_changed true).
     assert!(is_dependency_manifest(
       Path::new("pnpm-lock.yaml"),
-      Some(&PackageManager::Pnpm)
+      Some(&PackageManager::Pnpm),
+      true
     ));
     assert!(is_dependency_manifest(
       Path::new("package-lock.json"),
-      Some(&PackageManager::Npm)
+      Some(&PackageManager::Npm),
+      false
     ));
 
     // A lockfile for a *different* package manager than detected is not exempt.
     assert!(!is_dependency_manifest(
       Path::new("pnpm-lock.yaml"),
-      Some(&PackageManager::Npm)
+      Some(&PackageManager::Npm),
+      true
     ));
-    // Without a detected package manager, only package.json qualifies.
-    assert!(!is_dependency_manifest(Path::new("pnpm-lock.yaml"), None));
+
+    // package.json is exempt ONLY when the lockfile also changed (a real
+    // dependency update touches both) — lockfile analysis resolves the importers.
+    assert!(is_dependency_manifest(
+      Path::new("package.json"),
+      Some(&PackageManager::Pnpm),
+      true
+    ));
+    // package.json alone (no lockfile change) stays a global trigger so an
+    // uninstalled version-range edit can't silently under-include.
+    assert!(!is_dependency_manifest(
+      Path::new("package.json"),
+      Some(&PackageManager::Pnpm),
+      false
+    ));
+    // No package manager detected → lockfile_changed is false in practice →
+    // package.json is not exempt.
+    assert!(!is_dependency_manifest(
+      Path::new("package.json"),
+      None,
+      false
+    ));
 
     // Other workspace-root files (e.g. .nvmrc) are never dependency manifests,
     // so they keep triggering global invalidation.
     assert!(!is_dependency_manifest(
       Path::new(".nvmrc"),
-      Some(&PackageManager::Pnpm)
+      Some(&PackageManager::Pnpm),
+      true
     ));
     // Nested package.json is not the workspace-root manifest (never a global
     // trigger anyway — those match {workspaceRoot}/ only).
     assert!(!is_dependency_manifest(
       Path::new("libs/foo/package.json"),
-      Some(&PackageManager::Pnpm)
+      Some(&PackageManager::Pnpm),
+      true
     ));
   }
 }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -102,14 +102,18 @@ pub fn has_lockfile_changed(changed_files: &[ChangedFile], pm: &PackageManager) 
 /// lockfile in `sharedGlobals` short-circuits to "all projects" before that
 /// analysis ever runs (see `core`'s Step 1b), making it dead code.
 ///
-/// - The detected package manager's **lockfile** is always exempt — lockfile
-///   analysis owns it.
-/// - The workspace-root **`package.json`** is exempt only when the lockfile also
-///   changed (`lockfile_changed`). A dependency update touches both together, so
-///   lockfile analysis can resolve the affected importers. A `package.json`-only
-///   change (e.g. an uninstalled version-range edit, or a repo with no lockfile)
-///   has nothing to analyze, so it stays a global trigger rather than silently
-///   under-including.
+/// - The detected package manager's **lockfile** is a dependency manifest —
+///   lockfile analysis owns it.
+/// - The workspace-root **`package.json`** is a dependency manifest only when the
+///   lockfile also changed (`lockfile_changed`). A dependency update touches both
+///   together, so lockfile analysis can resolve the affected importers. A
+///   `package.json`-only change (e.g. an uninstalled version-range edit, or a
+///   repo with no lockfile) has nothing to analyze, so it is not treated as a
+///   manifest and stays a global trigger rather than silently under-including.
+///
+/// The caller must only honor this exemption when lockfile analysis is enabled
+/// (`strategy != none`); with analysis off there is no pipeline to process the
+/// file, so it should remain a global trigger. See `core`'s Step 1b.
 pub fn is_dependency_manifest(
   file_path: &Path,
   pm: Option<&PackageManager>,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3788,3 +3788,128 @@ export function unusedFn() {
     affected
   );
 }
+
+/// A lockfile/manifest listed in `sharedGlobals` must NOT globally invalidate:
+/// dependency-manifest changes flow through the lockfile analyzer instead, so
+/// only the importing project is affected. Regression guard for the change that
+/// exempts dependency manifests from `sharedGlobals` global invalidation.
+#[test]
+fn test_dependency_manifest_in_shared_globals_does_not_globally_invalidate() {
+  let (_tmp, root) = setup_lockfile_test_repo();
+
+  // The exact config that would otherwise short-circuit every lockfile bump to
+  // "all projects": lockfile + package.json listed in sharedGlobals.
+  fs::write(
+    root.join("nx.json"),
+    r#"{
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "sharedGlobals": [
+      "{workspaceRoot}/package.json",
+      "{workspaceRoot}/package-lock.json"
+    ]
+  }
+}"#,
+  )
+  .unwrap();
+  git_in(&root, &["add", "."]);
+  git_in(
+    &root,
+    &["commit", "-m", "add nx.json with lockfile in sharedGlobals"],
+  );
+
+  // Bump lib-a in the lockfile on a feature branch (lockfile is the only change).
+  git_in(&root, &["checkout", "-b", "feature"]);
+  fs::write(
+    root.join("package-lock.json"),
+    r#"{
+  "lockfileVersion": 3,
+  "packages": {
+    "": { "dependencies": { "lib-a": "^1.0.0" } },
+    "node_modules/lib-a": { "version": "2.0.0", "dependencies": { "lib-nested": "^1.0.0" } },
+    "node_modules/lib-nested": { "version": "1.0.0" }
+  }
+}"#,
+  )
+  .unwrap();
+  git_in(&root, &["add", "."]);
+  git_in(&root, &["commit", "-m", "bump lib-a"]);
+
+  let config = TrueAffectedConfig {
+    cwd: root.to_path_buf(),
+    base: "main".to_string(),
+    head: None,
+    root_ts_config: None,
+    projects: lockfile_projects(),
+    include: vec![],
+    ignored_paths: vec![],
+    lockfile_strategy: LockfileStrategy::Direct,
+  };
+
+  let profiler = Arc::new(Profiler::new(false));
+  let result = find_affected(config, profiler).expect("find_affected failed");
+  let affected = result.affected_projects;
+
+  assert!(
+    affected.contains(&"proj-a".to_string()),
+    "proj-a imports lib-a and must be affected. Got: {:?}",
+    affected
+  );
+  assert!(
+    !affected.contains(&"proj-c".to_string()),
+    "proj-c has no lib-a dependency and must NOT be affected — a lockfile listed \
+     in sharedGlobals must not globally invalidate. Got: {:?}",
+    affected
+  );
+}
+
+/// The manifest exemption must be narrow: a *non-manifest* file in
+/// `sharedGlobals` (e.g. .nvmrc) still globally invalidates every project.
+#[test]
+fn test_non_manifest_shared_global_still_globally_invalidates() {
+  let (_tmp, root) = setup_lockfile_test_repo();
+
+  fs::write(root.join(".nvmrc"), "20\n").unwrap();
+  fs::write(
+    root.join("nx.json"),
+    r#"{
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "sharedGlobals": ["{workspaceRoot}/.nvmrc"]
+  }
+}"#,
+  )
+  .unwrap();
+  git_in(&root, &["add", "."]);
+  git_in(&root, &["commit", "-m", "add nx.json + .nvmrc"]);
+
+  // Change the non-manifest global file on a feature branch.
+  git_in(&root, &["checkout", "-b", "feature"]);
+  fs::write(root.join(".nvmrc"), "22\n").unwrap();
+  git_in(&root, &["add", "."]);
+  git_in(&root, &["commit", "-m", "bump node version"]);
+
+  let config = TrueAffectedConfig {
+    cwd: root.to_path_buf(),
+    base: "main".to_string(),
+    head: None,
+    root_ts_config: None,
+    projects: lockfile_projects(),
+    include: vec![],
+    ignored_paths: vec![],
+    lockfile_strategy: LockfileStrategy::Direct,
+  };
+
+  let profiler = Arc::new(Profiler::new(false));
+  let result = find_affected(config, profiler).expect("find_affected failed");
+  let affected = result.affected_projects;
+
+  for proj in ["proj-a", "proj-b", "proj-c"] {
+    assert!(
+      affected.contains(&proj.to_string()),
+      "{proj} must be affected: a non-manifest sharedGlobals change globally \
+       invalidates. Got: {:?}",
+      affected
+    );
+  }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3975,3 +3975,73 @@ fn test_manifest_only_change_without_lockfile_still_globally_invalidates() {
     );
   }
 }
+
+/// Under `LockfileStrategy::None` there is no lockfile analysis (Step 5c), so a
+/// lockfile listed in `sharedGlobals` must fall back to global invalidation
+/// rather than being silently exempted (which would drop all -> 0). The manifest
+/// exemption only applies when analysis is enabled to process the change.
+#[test]
+fn test_lockfile_in_shared_globals_with_none_strategy_still_globally_invalidates() {
+  let (_tmp, root) = setup_lockfile_test_repo();
+
+  fs::write(
+    root.join("nx.json"),
+    r#"{
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "sharedGlobals": [
+      "{workspaceRoot}/package.json",
+      "{workspaceRoot}/package-lock.json"
+    ]
+  }
+}"#,
+  )
+  .unwrap();
+  git_in(&root, &["add", "."]);
+  git_in(
+    &root,
+    &["commit", "-m", "add nx.json with lockfile in sharedGlobals"],
+  );
+
+  // Bump lib-a in the lockfile on a feature branch (lockfile is the only change).
+  git_in(&root, &["checkout", "-b", "feature"]);
+  fs::write(
+    root.join("package-lock.json"),
+    r#"{
+  "lockfileVersion": 3,
+  "packages": {
+    "": { "dependencies": { "lib-a": "^1.0.0" } },
+    "node_modules/lib-a": { "version": "2.0.0", "dependencies": { "lib-nested": "^1.0.0" } },
+    "node_modules/lib-nested": { "version": "1.0.0" }
+  }
+}"#,
+  )
+  .unwrap();
+  git_in(&root, &["add", "."]);
+  git_in(&root, &["commit", "-m", "bump lib-a"]);
+
+  let config = TrueAffectedConfig {
+    cwd: root.to_path_buf(),
+    base: "main".to_string(),
+    head: None,
+    root_ts_config: None,
+    projects: lockfile_projects(),
+    include: vec![],
+    ignored_paths: vec![],
+    lockfile_strategy: LockfileStrategy::None,
+  };
+
+  let profiler = Arc::new(Profiler::new(false));
+  let result = find_affected(config, profiler).expect("find_affected failed");
+  let affected = result.affected_projects;
+
+  for proj in ["proj-a", "proj-b", "proj-c"] {
+    assert!(
+      affected.contains(&proj.to_string()),
+      "{proj} must be affected: with strategy=none there is no lockfile analysis, \
+       so a lockfile in sharedGlobals must globally invalidate, not drop to 0. \
+       Got: {:?}",
+      affected
+    );
+  }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3913,3 +3913,65 @@ fn test_non_manifest_shared_global_still_globally_invalidates() {
     );
   }
 }
+
+/// A `package.json` change with NO corresponding lockfile change has nothing for
+/// the lockfile analyzer to resolve, so it must stay a global trigger (safe
+/// fallback) rather than silently under-including. Only `package.json` + lockfile
+/// together (a real dependency update) is exempted.
+#[test]
+fn test_manifest_only_change_without_lockfile_still_globally_invalidates() {
+  let (_tmp, root) = setup_lockfile_test_repo();
+
+  fs::write(
+    root.join("nx.json"),
+    r#"{
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "sharedGlobals": [
+      "{workspaceRoot}/package.json",
+      "{workspaceRoot}/package-lock.json"
+    ]
+  }
+}"#,
+  )
+  .unwrap();
+  git_in(&root, &["add", "."]);
+  git_in(
+    &root,
+    &["commit", "-m", "add nx.json with manifest in sharedGlobals"],
+  );
+
+  // Edit package.json (bump lib-a range) WITHOUT touching the lockfile.
+  git_in(&root, &["checkout", "-b", "feature"]);
+  fs::write(
+    root.join("package.json"),
+    r#"{"dependencies": {"lib-a": "^2.0.0"}}"#,
+  )
+  .unwrap();
+  git_in(&root, &["add", "."]);
+  git_in(&root, &["commit", "-m", "bump lib-a range (no install)"]);
+
+  let config = TrueAffectedConfig {
+    cwd: root.to_path_buf(),
+    base: "main".to_string(),
+    head: None,
+    root_ts_config: None,
+    projects: lockfile_projects(),
+    include: vec![],
+    ignored_paths: vec![],
+    lockfile_strategy: LockfileStrategy::Direct,
+  };
+
+  let profiler = Arc::new(Profiler::new(false));
+  let result = find_affected(config, profiler).expect("find_affected failed");
+  let affected = result.affected_projects;
+
+  for proj in ["proj-a", "proj-b", "proj-c"] {
+    assert!(
+      affected.contains(&proj.to_string()),
+      "{proj} must be affected: a package.json change with no lockfile update \
+       has nothing to analyze, so it must globally invalidate. Got: {:?}",
+      affected
+    );
+  }
+}


### PR DESCRIPTION
## Problem

When a package **lockfile** or **`package.json`** is listed (transitively, via `default`) in an `nx.json` `sharedGlobals` namedInput, `find_affected` short-circuits to **all projects** before the lockfile analyzer runs — making `--lockfile-strategy` / `lockfileStrategy` dead code for exactly the files it exists for.

The gate lives in `core.rs` Step 1b:

```rust
if !global_triggers.is_empty() && !generate_report {
    // return ALL projects — never reaches Step 5c lockfile analysis
}
```

The source/asset partition already treats the lockfile as "handled separately" (it's excluded at Step 6 because lockfile analysis owns it), but the **global-invalidation gate was never taught the same thing**. So the two subsystems disagree, and the coarse one wins.

### Observed impact (verified on a ~350-project Nx workspace, `@front-ops/domino@1.4.0`)

| Changed file (only) | `--lockfile-strategy direct` | `none` |
|---|---|---|
| `package.json` script-only edit | **all 352** | all 352 |
| `.nvmrc` (in sharedGlobals) | all 352 | all 352 |
| real dep bump (both files change) | all 352 | all 352 |

`--lockfile-strategy none` changing nothing proves the fan-out is the `sharedGlobals` short-circuit, not lockfile logic. With the short-circuit removed, the same dep bump narrows to ~78 (`direct`) / ~219 (`full`) — the analyzer was already correct, just unreachable.

## Fix

Exempt dependency-manifest files from global invalidation so they flow through the existing lockfile + semantic pipeline instead of short-circuiting — but **only when that pipeline will actually process them**:

- **The lockfile is exempt when lockfile analysis is enabled** (`--lockfile-strategy` != `none`).
- **The workspace-root `package.json` is exempt only when analysis is enabled *and* the lockfile also changed in the same diff** — a real dependency update touches both, so lockfile analysis can resolve the affected importers.
- Otherwise the file **stays a global trigger** and invalidates every project. That covers: a `package.json`-only change (uninstalled version-range edit, or a repo with no lockfile), **anything under `--lockfile-strategy none`**, and any other global trigger (`.nvmrc`, `nx.json`, …).

Gating on analysis-enabled avoids a symmetric under-inclusion: without it, a lockfile in `sharedGlobals` under `none` would be neither globally invalidated nor analyzed, silently dropping **all → 0**.

`core.rs` detects the package manager once, up front, computes `lockfile_changed` (`has_lockfile_changed`) and `lockfile_analysis_enabled`, and filters `global_triggers` through `lockfile::is_dependency_manifest(...)`. Because the Step 1b short-circuit, the final union, and the report all key off `global_triggers`, filtering at the trigger source fixes all three at once.

## Semantics note for reviewers

With analysis on (the default `direct`), a lockfile — or a `package.json` accompanied by a lockfile change — in `sharedGlobals` is now analyzed instead of fanning out to all projects. This is the intended purpose of the lockfile analyzer; there was never a documented option meaning "invalidate all on lockfile change" — that was incidental to `sharedGlobals` membership. Under `--lockfile-strategy none`, behavior is **unchanged from `1.4.0`**: with no analysis to narrow the set, dependency manifests in `sharedGlobals` still globally invalidate. Happy to gate the whole thing behind an explicit opt-in flag if you'd prefer.

## Tests

- `lockfile::is_dependency_manifest` unit test — lockfile matches the detected PM (not other PMs'); `package.json` only with `lockfile_changed`; never `.nvmrc` or nested `package.json`.
- `test_dependency_manifest_in_shared_globals_does_not_globally_invalidate` (`Direct`) — lockfile in `sharedGlobals` + dep bump → only the importing project, not all.
- `test_manifest_only_change_without_lockfile_still_globally_invalidates` (`Direct`) — `package.json` edited with **no** lockfile update → globally invalidates (nothing to analyze).
- `test_lockfile_in_shared_globals_with_none_strategy_still_globally_invalidates` (`None`) — lockfile in `sharedGlobals` under `none` → globally invalidates (all), **not** 0.
- `test_non_manifest_shared_global_still_globally_invalidates` — `.nvmrc` in `sharedGlobals` still fans out to all projects.

`cargo fmt`, `cargo clippy --all-targets`, `cargo test --lib` (208 passed), and the `lockfile` + `named_inputs` integration groups all pass. (The pre-existing `test_asset_chain_with_intermediate_constant` shared-fixture test fails identically on clean `main` in a fresh clone — unrelated to this change.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved affected-project detection for dependency manifest and lockfile changes.
  * Lockfile updates now identify only projects with relevant dependencies instead of unnecessarily affecting unrelated projects.
  * Non-manifest global files continue to trigger updates across all projects.
  * Manifest changes retain expected global invalidation behavior when lockfile analysis is unavailable or disabled.
* **Tests**
  * Added regression coverage for lockfile, manifest, and global-input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->