### PR TITLE
fix(workspace): keep generic-loader project roots workspace-relative

### DIFF
--- a/src/workspace/workspaces.rs
+++ b/src/workspace/workspaces.rs
@@ -128,14 +128,10 @@ fn parse_package_json(path: &Path, cwd: &Path) -> Result<Project> {
     .parent()
     .ok_or_else(|| DominoError::Other("Invalid package path".to_string()))?;
 
-  let source_root = if cwd.is_absolute() {
-    project_dir.to_path_buf()
-  } else {
-    project_dir
-      .strip_prefix(cwd)
-      .unwrap_or(project_dir)
-      .to_path_buf()
-  };
+  let source_root = project_dir
+    .strip_prefix(cwd)
+    .unwrap_or(project_dir)
+    .to_path_buf();
 
   Ok(Project {
     name: pkg_json.name,
@@ -325,6 +321,9 @@ mod tests {
     let projects = get_projects(root).unwrap();
 
     assert_eq!(projects.len(), 1);
-    assert_eq!(projects[0].source_root, root.join("packages/utils"));
+    assert_eq!(
+      projects[0].source_root,
+      std::path::PathBuf::from("packages/utils")
+    );
   }
 }


### PR DESCRIPTION
Fixes #73.

### Problem

In generic workspace mode (npm/yarn/pnpm/bun, no `nx.json`), the affected set is always empty when the CLI is run from an absolute cwd — i.e. every real-world invocation. Discovery and the semantic trace both work, but nothing is ever attributed.

`parse_package_json` (`src/workspace/workspaces.rs`) kept `source_root`/`root` **absolute** whenever `cwd` is absolute, while changed files parsed from the `git diff` headers (`src/git.rs::parse_diff`) are **repo-relative**. `ProjectIndex::resolve_packages` (`src/utils.rs`) decides ownership via `file_path.starts_with(root)`, and a relative path never starts with an absolute root — so every lookup returns empty. The Nx loader (`src/workspace/nx.rs`) already strips the cwd prefix, which is why Nx-mode attribution works.

Net effect: generic mode returns a silent false-green (empty affected set) if used for CI gating.

### Fix

Strip the cwd prefix unconditionally in `parse_package_json`, matching the Nx loader. The `cwd.is_absolute()` branch that preserved the absolute path is removed; the `strip_prefix(cwd).unwrap_or(project_dir)` fallback already handles the relative-cwd case. The one unit test asserting the old absolute-root behavior is updated to expect the workspace-relative root.

### Verification

- `cargo test` — all unit tests pass.
- Verified end-to-end against `nx affected` on a 250-package pnpm monorepo (Nx 22): 251 projects discovered via `pnpm-workspace.yaml`, correct affected sets across a 14-scenario matrix (comment-only edit → source package only; body change in a shared lib → exact consumer set incl. transitive chains; type-shape change → 3 precise projects vs 16 from Nx's file-graph).

Related but distinct: #70 (Nx-mode discovery missing inferred projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated workspace path handling so project source paths are now derived more consistently from the current working directory.
  * In setups with an absolute workspace root, source paths will now resolve to cleaner relative paths instead of absolute paths when possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->