### PR TITLE
fix(git): recover deleted symbols from the base revision (supersedes #72)

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -222,6 +222,39 @@ fn find_affected_internal(
       )
       .collect();
 
+    // Recover symbols removed by pure-deletion hunks. Their lines are gone from
+    // the working tree, so `find_node_at_line` above (which reads the current
+    // file) can't see them; instead we re-parse the file at the base revision
+    // and resolve the enclosing top-level symbol at each deleted line. This is
+    // what lets dependents of a deleted symbol — an object property, a `switch`
+    // case, or a whole exported declaration — be traced. Consumers still import
+    // the symbol in the current graph, so the traversal below reaches them.
+    let deleted_symbols: Vec<String> = if changed_file.deleted_lines.is_empty() {
+      Vec::new()
+    } else {
+      match git::get_file_at_revision(&config.cwd, &merge_base, file_path) {
+        Ok(Some(base_source)) => {
+          analyzer.find_deleted_symbols(file_path, &base_source, &changed_file.deleted_lines)
+        }
+        Ok(None) => Vec::new(),
+        Err(e) => {
+          debug!(
+            "Failed to read base revision of {:?} for deleted-symbol recovery: {}",
+            file_path, e
+          );
+          Vec::new()
+        }
+      }
+    };
+    if !deleted_symbols.is_empty() {
+      debug!(
+        "Recovered {} deleted symbol(s) from base revision of {:?}: {:?}",
+        deleted_symbols.len(),
+        file_path,
+        deleted_symbols
+      );
+    }
+
     // Add all packages that own this file (multiple projects can share the same sourceRoot).
     // Uses the unfiltered lookup — a directly changed file always belongs to its project
     // regardless of tsconfig excludes (spec files, stories, config files all count).
@@ -255,16 +288,31 @@ fn find_affected_internal(
             }
           }
         }
+
+        // Deleted symbols have no surviving new-side line; record them at line 0
+        // so the report still explains why the owning package is affected.
+        for symbol in &deleted_symbols {
+          project_causes
+            .entry(pkg.clone())
+            .or_default()
+            .push(AffectCause::DirectChange {
+              file: file_path.clone(),
+              symbol: Some(symbol.clone()),
+              line: 0,
+            });
+        }
       }
     }
 
-    // Pre-deduplicate: collect unique symbols across all changed lines before tracing.
-    // This avoids redundant recursive reference traversals when many changed lines
-    // map to the same symbol (e.g., additions inside a single large exported object).
-    let unique_symbols: FxHashSet<&String> = symbols_by_line
+    // Pre-deduplicate: collect unique symbols across all changed lines (plus any
+    // recovered from deletions) before tracing. This avoids redundant recursive
+    // reference traversals when many changed lines map to the same symbol (e.g.
+    // additions inside a single large exported object).
+    let mut unique_symbols: FxHashSet<&String> = symbols_by_line
       .iter()
       .flat_map(|(_, symbols)| symbols.iter())
       .collect();
+    unique_symbols.extend(deleted_symbols.iter());
 
     if unique_symbols.is_empty() {
       debug!(
@@ -273,9 +321,10 @@ fn find_affected_internal(
       );
     } else {
       debug!(
-        "Found {} unique symbols from {} changed lines in {:?}",
+        "Found {} unique symbols from {} changed and {} deleted lines in {:?}",
         unique_symbols.len(),
         changed_file.changed_lines.len(),
+        changed_file.deleted_lines.len(),
         file_path
       );
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -191,9 +191,9 @@ fn parse_diff(diff: &str) -> Result<Vec<ChangedFile>> {
       // expand to every line in the new-side range `Z..Z+W`, so symbols that
       // live mid-hunk (not just at the hunk's starting line) are visible to
       // downstream AST lookups. When `,W` is omitted, git's convention is a
-      // single-line hunk (count = 1). Pure deletion hunks (`W == 0`) produce
-      // an empty range — see the `has_hunks` branch below for how those are
-      // preserved.
+      // single-line hunk (count = 1). Pure deletion hunks (`W == 0`) have no
+      // new-side lines, so they anchor to line `Z` (the line just before the
+      // deletion) — see the `count == 0` branch below.
       let ranges: Vec<std::ops::Range<usize>> = line_regex
         .captures_iter(file_diff)
         .filter_map(|caps| {
@@ -211,6 +211,18 @@ fn parse_diff(diff: &str) -> Result<Vec<ChangedFile>> {
                 .ok()
             })
             .unwrap_or(1);
+          if count == 0 {
+            // Deletion-only hunk (`+Z,0`). The removed lines are gone from the
+            // new file, but whatever top-level symbol *enclosed* them (e.g. an
+            // exported object losing a property, a switch losing a case) is still
+            // changed, and its dependents are affected. Anchor to the new-side
+            // line `Z` — the line just before the deletion point, still inside
+            // the enclosing symbol — so the downstream AST lookup can resolve
+            // that symbol and trace its references. Clamp to 1 for deletions at
+            // the top of the file (git emits `+0,0`).
+            let anchor = start.max(1);
+            return Some(anchor..anchor + 1);
+          }
           Some(start..start + count)
         })
         .collect();
@@ -522,12 +534,12 @@ index 1234567..abcdefg 100644
     assert_eq!(result[0].changed_lines, vec![1]);
   }
 
-  /// A pure-deletion hunk (`+Z,0`) has no new-side lines to scan and must
-  /// contribute zero entries to `changed_lines`. Pair it with a normal hunk
-  /// so the file-skip branch (which triggers on a fully empty result) is not
-  /// what's actually being tested.
+  /// A deletion hunk (`+Z,0`) anchors to its new-side line `Z` so the enclosing
+  /// symbol stays traceable, even when paired with a normal addition hunk. Here
+  /// the deletion at `+5,0` contributes anchor line 5, alongside the addition
+  /// hunk's lines 21 and 22.
   #[test]
-  fn test_parse_diff_pure_deletion_hunk_contributes_zero() {
+  fn test_parse_diff_deletion_hunk_anchors_alongside_addition() {
     let diff = r#"diff --git a/src/foo.ts b/src/foo.ts
 index 1234567..abcdefg 100644
 --- a/src/foo.ts
@@ -543,17 +555,17 @@ index 1234567..abcdefg 100644
 
     let result = parse_diff(diff).unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].changed_lines, vec![21, 22]);
+    assert_eq!(result[0].changed_lines, vec![5, 21, 22]);
   }
 
-  /// A file whose only hunks are deletions (`+Z,0`) must still be kept in
-  /// the result with an empty `changed_lines`. Dropping it would hide real
-  /// source changes — deleting an exported symbol is a meaningful change
-  /// even though there are no new-file lines to AST-lookup. Downstream in
-  /// `core.rs`, the file's owning package is still marked affected because
-  /// the file path is present.
+  /// A file whose only hunks are deletions (`+Z,0`) is kept in the result and
+  /// anchors to the new-side line of each deletion (line `Z`), so the symbol
+  /// that enclosed the removed lines — and therefore the deleted symbol's
+  /// dependents — can be traced downstream. Previously such files were kept with
+  /// an empty `changed_lines`, which left the file's owning package marked but
+  /// caused the reference cascade to be skipped, under-reporting dependents.
   #[test]
-  fn test_parse_diff_deletion_only_file_kept_with_empty_lines() {
+  fn test_parse_diff_deletion_only_file_anchors_to_enclosing_symbol_line() {
     let diff = r#"diff --git a/src/foo.ts b/src/foo.ts
 index 1234567..abcdefg 100644
 --- a/src/foo.ts
@@ -567,7 +579,7 @@ index 1234567..abcdefg 100644
     let result = parse_diff(diff).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].file_path.to_str().unwrap(), "src/foo.ts");
-    assert!(result[0].changed_lines.is_empty());
+    assert_eq!(result[0].changed_lines, vec![5]);
   }
 
   /// Symmetric hunk header — old and new sides both carry a count. Common in
@@ -593,5 +605,33 @@ index 1234567..abcdefg 100644
     let result = parse_diff(diff).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].changed_lines, vec![3, 4, 5]);
+  }
+
+  /// Regression for the deletion-only under-detection bug.
+  ///
+  /// `git diff --unified=0` emits a `+Z,0` hunk when a line is removed. The
+  /// removed content no longer exists in the new file, but the *enclosing*
+  /// top-level symbol (here the exported `declarativeCalculations` object) is
+  /// still meaningfully changed, and every project that consumes that symbol is
+  /// affected. To trace them, the deletion must anchor to the new-side line `Z`
+  /// — the line immediately before the deletion point, which is still inside the
+  /// enclosing symbol — so the downstream AST lookup can resolve the symbol.
+  ///
+  /// Before the fix, deletion hunks contributed nothing to `changed_lines`, so
+  /// symbol extraction found nothing and the reference cascade was skipped,
+  /// under-reporting the deleted symbol's dependents.
+  #[test]
+  fn test_parse_diff_deletion_only_hunk_anchors_to_new_side_line() {
+    let diff = r#"diff --git a/src/attrs.ts b/src/attrs.ts
+index 1234567..abcdefg 100644
+--- a/src/attrs.ts
++++ b/src/attrs.ts
+@@ -495 +494,0 @@ export const declarativeCalculations = {
+-  'Commissions & Fees': { alternative: ['Bank Charges'] },
+"#;
+
+    let result = parse_diff(diff).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].changed_lines, vec![494]);
   }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -626,9 +626,9 @@ index 1234567..abcdefg 100644
 
   /// Symmetric hunk header — old and new sides both carry a count. Common in
   /// diffs with non-zero context (`--unified=N` for N > 0) or when an edit
-  /// replaces a block with another block of the same size. The greedy `.*`
-  /// in `LINE_RE` already handles this; the test locks it in against future
-  /// regex tweaks.
+  /// replaces a block with another block of the same size. `LINE_RE`'s explicit
+  /// old/new capture groups (`-(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))?`) handle this;
+  /// the test locks it in against future regex tweaks.
   #[test]
   fn test_parse_diff_symmetric_hunk_with_old_and_new_counts() {
     let diff = r#"diff --git a/src/foo.ts b/src/foo.ts

--- a/src/git.rs
+++ b/src/git.rs
@@ -8,8 +8,13 @@ use tracing::{debug, warn};
 
 static FILE_RE: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r#"(?:["\s]a/)(.*)(?:["\s]b/)"#).expect("file regex is valid"));
-static LINE_RE: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new(r"@@ -.* \+(\d+)(?:,(\d+))? @@").expect("line regex is valid"));
+/// Captures both sides of a hunk header `@@ -X,Y +Z,W @@`:
+/// group 1 = old start `X`, group 2 = old count `Y` (optional),
+/// group 3 = new start `Z`, group 4 = new count `W` (optional).
+/// The old side is needed to recover symbols removed by pure-deletion hunks.
+static LINE_RE: LazyLock<Regex> = LazyLock::new(|| {
+  Regex::new(r"@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@").expect("line regex is valid")
+});
 
 /// Detect the default branch (tries origin/main, then origin/master)
 pub fn detect_default_branch(repo_path: &Path) -> String {
@@ -129,6 +134,39 @@ pub fn get_diff(repo_path: &Path, base: &str, head: Option<&str>) -> Result<Stri
   )
 }
 
+/// Read the contents of a file as it existed at a given revision.
+///
+/// `path` is interpreted relative to `repo_path` (the `./` prefix makes git
+/// resolve it against the working directory rather than the repo top-level),
+/// matching the `--relative` paths produced by [`get_diff`]. Returns
+/// `Ok(None)` when the file does not exist at that revision — e.g. a newly
+/// added file, for which there is no base content to recover — so callers can
+/// treat "no base" as "nothing to trace" without erroring.
+pub fn get_file_at_revision(
+  repo_path: &Path,
+  revision: &str,
+  path: &Path,
+) -> Result<Option<String>> {
+  let spec = format!("{}:./{}", revision, path.display());
+  let output = Command::new("git")
+    .args(["show", &spec])
+    .current_dir(repo_path)
+    .output()
+    .map_err(|e| DominoError::Other(format!("Failed to execute git show: {}", e)))?;
+
+  if !output.status.success() {
+    debug!(
+      "git show {} returned non-zero (file likely absent at base); skipping",
+      spec
+    );
+    return Ok(None);
+  }
+
+  Ok(Some(String::from_utf8(output.stdout).unwrap_or_else(|e| {
+    String::from_utf8_lossy(e.as_bytes()).into_owned()
+  })))
+}
+
 /// Parse git diff output to extract changed files and line numbers.
 /// Returns the changed files along with the computed merge-base SHA.
 ///
@@ -187,56 +225,55 @@ fn parse_diff(diff: &str) -> Result<Vec<ChangedFile>> {
       let is_rename_or_copy = new_path.is_some();
       let file_path = new_path.unwrap_or(file_path);
 
-      // Extract changed line numbers. For each hunk header `@@ -X,Y +Z,W @@`
-      // expand to every line in the new-side range `Z..Z+W`, so symbols that
-      // live mid-hunk (not just at the hunk's starting line) are visible to
-      // downstream AST lookups. When `,W` is omitted, git's convention is a
-      // single-line hunk (count = 1). Pure deletion hunks (`W == 0`) have no
-      // new-side lines, so they anchor to line `Z` (the line just before the
-      // deletion) — see the `count == 0` branch below.
-      let ranges: Vec<std::ops::Range<usize>> = line_regex
-        .captures_iter(file_diff)
-        .filter_map(|caps| {
-          let start_str = caps.get(1)?.as_str();
-          let start: usize = start_str
+      // Extract line numbers from each hunk header `@@ -X,Y +Z,W @@`.
+      //
+      // A hunk that adds or modifies lines (`W >= 1`) expands to every new-side
+      // line `Z..Z+W`, so symbols living mid-hunk — not just at the hunk's start
+      // — are visible to the downstream AST lookup. When `,W` / `,Y` is omitted,
+      // git's convention is a single line (count = 1).
+      //
+      // A pure-deletion hunk (`W == 0`) has no new-side line to look up: the
+      // removed code is gone from the working tree. But the symbol that enclosed
+      // it (an exported object losing a property, a `switch` losing a case, or an
+      // entire top-level declaration) is still changed, and its dependents are
+      // affected. We record the *old-side* lines `X..X+Y` in `deleted_lines`;
+      // downstream (`core.rs`) re-parses the base revision at those lines to
+      // recover the enclosing symbol and trace its references. Using the old side
+      // — rather than anchoring to a surviving new-side line — is what makes
+      // deleting a whole symbol resolvable and avoids mis-attributing the change
+      // to whichever symbol now happens to occupy the deletion point.
+      let mut changed_lines: Vec<usize> = Vec::new();
+      let mut deleted_lines: Vec<usize> = Vec::new();
+      let parse_group = |caps: &regex::Captures, idx: usize| -> Option<usize> {
+        caps.get(idx).and_then(|m| {
+          m.as_str()
             .parse()
-            .inspect_err(|e| warn!("Failed to parse hunk start line '{}': {}", start_str, e))
-            .ok()?;
-          let count: usize = caps
-            .get(2)
-            .and_then(|m| {
-              m.as_str()
-                .parse()
-                .inspect_err(|e| warn!("Failed to parse hunk count '{}': {}", m.as_str(), e))
-                .ok()
-            })
-            .unwrap_or(1);
-          if count == 0 {
-            // Deletion-only hunk (`+Z,0`). The removed lines are gone from the
-            // new file, but whatever top-level symbol *enclosed* them (e.g. an
-            // exported object losing a property, a switch losing a case) is still
-            // changed, and its dependents are affected. Anchor to the new-side
-            // line `Z` — the line just before the deletion point, still inside
-            // the enclosing symbol — so the downstream AST lookup can resolve
-            // that symbol and trace its references. Clamp to 1 for deletions at
-            // the top of the file (git emits `+0,0`).
-            let anchor = start.max(1);
-            return Some(anchor..anchor + 1);
-          }
-          Some(start..start + count)
+            .inspect_err(|e| warn!("Failed to parse hunk field '{}': {}", m.as_str(), e))
+            .ok()
         })
-        .collect();
-      let has_hunks = !ranges.is_empty();
-      let mut changed_lines: Vec<usize> = ranges.into_iter().flatten().collect();
+      };
+      for caps in line_regex.captures_iter(file_diff) {
+        let (Some(old_start), Some(new_start)) = (parse_group(&caps, 1), parse_group(&caps, 3))
+        else {
+          continue;
+        };
+        let old_count = parse_group(&caps, 2).unwrap_or(1);
+        let new_count = parse_group(&caps, 4).unwrap_or(1);
+        if new_count == 0 {
+          deleted_lines.extend(old_start..old_start + old_count);
+        } else {
+          changed_lines.extend(new_start..new_start + new_count);
+        }
+      }
 
       if changed_lines.is_empty() {
         if is_rename_or_copy {
           changed_lines.push(1);
-        } else if has_hunks {
-          // Deletion-only file (every hunk is `+Z,0`). Keep the file entry
-          // with no line numbers so its owning package is still marked as
-          // affected — deleting an exported symbol is a real change even
-          // though there's nothing in the new file to AST-lookup.
+        } else if !deleted_lines.is_empty() {
+          // Deletion-only file (every hunk is `+Z,0`). It has no new-side lines
+          // to AST-lookup, but `deleted_lines` lets us recover the removed
+          // symbols from the base revision downstream, and the file's owning
+          // package is still marked affected because its path is present.
           debug!("Only deletion hunks for file: {}", file_path);
         } else if file_diff
           .lines()
@@ -252,6 +289,7 @@ fn parse_diff(diff: &str) -> Result<Vec<ChangedFile>> {
       Some(ChangedFile {
         file_path: file_path.into(),
         changed_lines,
+        deleted_lines,
       })
     })
     .collect();
@@ -534,12 +572,13 @@ index 1234567..abcdefg 100644
     assert_eq!(result[0].changed_lines, vec![1]);
   }
 
-  /// A deletion hunk (`+Z,0`) anchors to its new-side line `Z` so the enclosing
-  /// symbol stays traceable, even when paired with a normal addition hunk. Here
-  /// the deletion at `+5,0` contributes anchor line 5, alongside the addition
-  /// hunk's lines 21 and 22.
+  /// A pure-deletion hunk (`+Z,0`) records its *old-side* lines in
+  /// `deleted_lines` (never in `changed_lines`), while a paired addition hunk
+  /// contributes its new-side lines to `changed_lines`. Here the deletion at
+  /// `-5,3` removed base lines 5, 6, 7 and the addition at `+21,2` added new
+  /// lines 21, 22.
   #[test]
-  fn test_parse_diff_deletion_hunk_anchors_alongside_addition() {
+  fn test_parse_diff_deletion_hunk_records_old_side_alongside_addition() {
     let diff = r#"diff --git a/src/foo.ts b/src/foo.ts
 index 1234567..abcdefg 100644
 --- a/src/foo.ts
@@ -555,17 +594,19 @@ index 1234567..abcdefg 100644
 
     let result = parse_diff(diff).unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].changed_lines, vec![5, 21, 22]);
+    assert_eq!(result[0].changed_lines, vec![21, 22]);
+    assert_eq!(result[0].deleted_lines, vec![5, 6, 7]);
   }
 
-  /// A file whose only hunks are deletions (`+Z,0`) is kept in the result and
-  /// anchors to the new-side line of each deletion (line `Z`), so the symbol
-  /// that enclosed the removed lines — and therefore the deleted symbol's
-  /// dependents — can be traced downstream. Previously such files were kept with
-  /// an empty `changed_lines`, which left the file's owning package marked but
-  /// caused the reference cascade to be skipped, under-reporting dependents.
+  /// A file whose only hunks are deletions (`+Z,0`) is kept in the result with
+  /// an empty `changed_lines` but the removed base-revision lines in
+  /// `deleted_lines`. Downstream, those lines re-parse the base revision to
+  /// recover the deleted symbol and trace its dependents — while the file's own
+  /// package is still marked because its path is present. Previously such files
+  /// were kept with empty `changed_lines` and nothing else, so the reference
+  /// cascade was skipped and dependents were under-reported.
   #[test]
-  fn test_parse_diff_deletion_only_file_anchors_to_enclosing_symbol_line() {
+  fn test_parse_diff_deletion_only_file_records_deleted_lines() {
     let diff = r#"diff --git a/src/foo.ts b/src/foo.ts
 index 1234567..abcdefg 100644
 --- a/src/foo.ts
@@ -579,7 +620,8 @@ index 1234567..abcdefg 100644
     let result = parse_diff(diff).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].file_path.to_str().unwrap(), "src/foo.ts");
-    assert_eq!(result[0].changed_lines, vec![5]);
+    assert!(result[0].changed_lines.is_empty());
+    assert_eq!(result[0].deleted_lines, vec![5, 6, 7]);
   }
 
   /// Symmetric hunk header — old and new sides both carry a count. Common in
@@ -610,18 +652,18 @@ index 1234567..abcdefg 100644
   /// Regression for the deletion-only under-detection bug.
   ///
   /// `git diff --unified=0` emits a `+Z,0` hunk when a line is removed. The
-  /// removed content no longer exists in the new file, but the *enclosing*
-  /// top-level symbol (here the exported `declarativeCalculations` object) is
-  /// still meaningfully changed, and every project that consumes that symbol is
-  /// affected. To trace them, the deletion must anchor to the new-side line `Z`
-  /// — the line immediately before the deletion point, which is still inside the
-  /// enclosing symbol — so the downstream AST lookup can resolve the symbol.
+  /// removed content no longer exists in the new file, so it contributes
+  /// nothing to `changed_lines`; instead its *old-side* line (the shorthand
+  /// `-495` = base line 495) is recorded in `deleted_lines`. Downstream, that
+  /// line re-parses the base revision, resolves the enclosing top-level symbol
+  /// (here the exported `declarativeCalculations` object), and traces every
+  /// project that consumes it.
   ///
-  /// Before the fix, deletion hunks contributed nothing to `changed_lines`, so
-  /// symbol extraction found nothing and the reference cascade was skipped,
+  /// Before the fix, deletion hunks contributed nothing at all, so symbol
+  /// extraction found nothing and the reference cascade was skipped,
   /// under-reporting the deleted symbol's dependents.
   #[test]
-  fn test_parse_diff_deletion_only_hunk_anchors_to_new_side_line() {
+  fn test_parse_diff_deletion_only_hunk_records_old_side_line() {
     let diff = r#"diff --git a/src/attrs.ts b/src/attrs.ts
 index 1234567..abcdefg 100644
 --- a/src/attrs.ts
@@ -632,6 +674,30 @@ index 1234567..abcdefg 100644
 
     let result = parse_diff(diff).unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].changed_lines, vec![494]);
+    assert!(result[0].changed_lines.is_empty());
+    assert_eq!(result[0].deleted_lines, vec![495]);
+  }
+
+  /// Deleting an entire multi-line top-level symbol at the very top of a file
+  /// produces `@@ -1,N +0,0 @@`. The whole old-side range must land in
+  /// `deleted_lines` so the base revision can be re-parsed to recover the
+  /// deleted declaration — the case the earlier new-side "anchor" heuristic
+  /// could not handle (it would resolve whichever symbol now occupies line 1).
+  #[test]
+  fn test_parse_diff_deletion_of_leading_symbol_records_full_old_range() {
+    let diff = r#"diff --git a/src/foo.ts b/src/foo.ts
+index 1234567..abcdefg 100644
+--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -1,3 +0,0 @@
+-export const Removed = {
+-  value: 1,
+-};
+"#;
+
+    let result = parse_diff(diff).unwrap();
+    assert_eq!(result.len(), 1);
+    assert!(result[0].changed_lines.is_empty());
+    assert_eq!(result[0].deleted_lines, vec![1, 2, 3]);
   }
 }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1257,6 +1257,7 @@ mod tests {
     let files = vec![ChangedFile {
       file_path: "package-lock.json".into(),
       changed_lines: vec![1],
+      deleted_lines: vec![],
     }];
     assert!(has_lockfile_changed(&files, &PackageManager::Npm));
   }
@@ -1266,6 +1267,7 @@ mod tests {
     let files = vec![ChangedFile {
       file_path: "src/index.ts".into(),
       changed_lines: vec![1],
+      deleted_lines: vec![],
     }];
     assert!(!has_lockfile_changed(&files, &PackageManager::Npm));
   }
@@ -1275,6 +1277,7 @@ mod tests {
     let files = vec![ChangedFile {
       file_path: "yarn.lock".into(),
       changed_lines: vec![1],
+      deleted_lines: vec![],
     }];
     assert!(has_lockfile_changed(&files, &PackageManager::Yarn));
   }
@@ -1284,6 +1287,7 @@ mod tests {
     let files = vec![ChangedFile {
       file_path: "pnpm-lock.yaml".into(),
       changed_lines: vec![1],
+      deleted_lines: vec![],
     }];
     assert!(has_lockfile_changed(&files, &PackageManager::Pnpm));
   }
@@ -1293,6 +1297,7 @@ mod tests {
     let files = vec![ChangedFile {
       file_path: "bun.lock".into(),
       changed_lines: vec![1],
+      deleted_lines: vec![],
     }];
     assert!(has_lockfile_changed(&files, &PackageManager::Bun));
   }

--- a/src/named_inputs.rs
+++ b/src/named_inputs.rs
@@ -545,18 +545,22 @@ mod tests {
       ChangedFile {
         file_path: PathBuf::from(".github/workflows/ci.yml"),
         changed_lines: vec![],
+        deleted_lines: vec![],
       },
       ChangedFile {
         file_path: PathBuf::from("nx.json"),
         changed_lines: vec![],
+        deleted_lines: vec![],
       },
       ChangedFile {
         file_path: PathBuf::from("package.json"),
         changed_lines: vec![],
+        deleted_lines: vec![],
       },
       ChangedFile {
         file_path: PathBuf::from("libs/foo/src/index.ts"),
         changed_lines: vec![],
+        deleted_lines: vec![],
       },
     ];
 
@@ -604,6 +608,7 @@ mod tests {
     let changed = vec![ChangedFile {
       file_path: PathBuf::from("libs/foo/src/index.ts"),
       changed_lines: vec![],
+      deleted_lines: vec![],
     }];
 
     assert!(check_global_invalidation(&resolved, &changed).is_empty());

--- a/src/report.rs
+++ b/src/report.rs
@@ -1816,10 +1816,19 @@ fn generate_details_html(report: &AffectedReport) -> String {
         AffectCause::DirectChange { file, symbol, line } => {
           html.push_str("<span class=\"cause-type direct\">Direct Change</span>");
           html.push_str("<div class=\"cause-details\">");
+          // `line == 0` means there is no specific new-side line: either a symbol
+          // recovered from a deletion (base revision) or a whole-file/asset
+          // change. Rendering "(line 0)" reads oddly, so label a deleted symbol
+          // "(deleted)" and omit the locator when there's no symbol either.
+          let location = if *line == 0 {
+            if symbol.is_some() { " (deleted)" } else { "" }.to_string()
+          } else {
+            format!(" (line {})", line)
+          };
           html.push_str(&format!(
-            "File: <span class=\"code-path\">{}</span> (line {})",
+            "File: <span class=\"code-path\">{}</span>{}",
             file.display(),
-            line
+            location
           ));
           if let Some(sym) = symbol {
             html.push_str(&format!(

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -315,6 +315,51 @@ impl WorkspaceAnalyzer {
       exports,
     })
   }
+
+  /// Parse an in-memory `source` string into a self-contained
+  /// [`FileSemanticData`], picking the source type from `file_path`'s
+  /// extension. Unlike [`parse_single_file`], this reads no file from disk and
+  /// skips import/export extraction — it exists to run [`find_top_level_symbols`]
+  /// against a base-revision snapshot of deleted code, which is never added to
+  /// `self.files`.
+  fn parse_source(file_path: &Path, source: String) -> Result<FileSemanticData> {
+    let source_type = SourceType::from_path(file_path)
+      .unwrap_or_else(|_| SourceType::default().with_typescript(true));
+
+    let allocator = Allocator::default();
+    let parser = Parser::new(&allocator, &source, source_type);
+    let parse_result = parser.parse();
+
+    if !parse_result.errors.is_empty() {
+      debug!(
+        "Parse errors in base revision of {:?}: {} errors",
+        file_path,
+        parse_result.errors.len()
+      );
+      // Continue anyway — a partial AST is still enough to resolve the
+      // enclosing declaration at a deleted line.
+    }
+
+    let semantic_ret = SemanticBuilder::new()
+      .with_cfg(true)
+      .with_check_syntax_error(false)
+      .build(&parse_result.program);
+
+    // Safety: identical to `parse_single_file` — the semantic data borrows from
+    // `allocator`, which is moved into the returned `FileSemanticData` and lives
+    // exactly as long as the semantic data does.
+    let semantic = unsafe {
+      std::mem::transmute::<oxc_semantic::Semantic<'_>, oxc_semantic::Semantic<'static>>(
+        semantic_ret.semantic,
+      )
+    };
+
+    Ok(FileSemanticData {
+      source,
+      allocator,
+      semantic,
+    })
+  }
 }
 
 /// Visitor to collect dynamic imports (import() expressions)
@@ -811,6 +856,28 @@ impl WorkspaceAnalyzer {
       .get(file_path)
       .ok_or_else(|| DominoError::FileNotFound(file_path.display().to_string()))?;
 
+    let result = Self::find_top_level_symbols(file_data, line, column);
+
+    if let Some(start_time) = start {
+      self
+        .profiler
+        .record_symbol_extraction(start_time.elapsed().as_nanos() as u64);
+    }
+
+    result
+  }
+
+  /// Resolve the enclosing top-level symbol(s) at `line`/`column` within an
+  /// already-parsed file. Shared by [`WorkspaceAnalyzer::find_node_at_line`]
+  /// (working-tree files) and [`WorkspaceAnalyzer::find_deleted_symbols`]
+  /// (base-revision snapshots of deleted code). Takes `&FileSemanticData`
+  /// rather than `&self` so it can run against a one-off parse that never
+  /// enters `self.files`.
+  fn find_top_level_symbols(
+    file_data: &FileSemanticData,
+    line: usize,
+    column: usize,
+  ) -> Result<Vec<String>> {
     // Get the exact offset using both line and column
     let line_start = crate::utils::line_to_offset(&file_data.source, line)
       .ok_or_else(|| DominoError::Other(format!("Invalid line number: {}", line)))?;
@@ -905,12 +972,6 @@ impl WorkspaceAnalyzer {
         if top_level_name.is_none() && !export_decl.specifiers.is_empty() {
           let specifier_names = specifier_names_on_line(export_decl);
           if !specifier_names.is_empty() {
-            // Record profiling time
-            if let Some(start_time) = start {
-              self
-                .profiler
-                .record_symbol_extraction(start_time.elapsed().as_nanos() as u64);
-            }
             return Ok(specifier_names);
           }
         }
@@ -933,12 +994,6 @@ impl WorkspaceAnalyzer {
     // If we found the symbol at the current node level, return it early
     if found_export_wrapper {
       if let Some(name) = top_level_name.take() {
-        // Record profiling time
-        if let Some(start_time) = start {
-          self
-            .profiler
-            .record_symbol_extraction(start_time.elapsed().as_nanos() as u64);
-        }
         return Ok(vec![name]);
       }
     }
@@ -963,12 +1018,6 @@ impl WorkspaceAnalyzer {
           if top_level_name.is_none() && !export_decl.specifiers.is_empty() {
             let specifier_names = specifier_names_on_line(export_decl);
             if !specifier_names.is_empty() {
-              // Record profiling time
-              if let Some(start_time) = start {
-                self
-                  .profiler
-                  .record_symbol_extraction(start_time.elapsed().as_nanos() as u64);
-              }
               return Ok(specifier_names);
             }
           }
@@ -1022,17 +1071,66 @@ impl WorkspaceAnalyzer {
       current_id = parent_id;
     }
 
-    // Record profiling time
-    if let Some(start_time) = start {
-      self
-        .profiler
-        .record_symbol_extraction(start_time.elapsed().as_nanos() as u64);
-    }
-
     // Return the top-level declaration if found, otherwise empty
     // When empty is returned, it means the line doesn't contain a trackable symbol
     // (e.g., object literal properties, comments, or code not in a top-level declaration)
     Ok(top_level_name.map(|name| vec![name]).unwrap_or_default())
+  }
+
+  /// Recover the top-level symbols that enclosed a set of *base-revision* lines.
+  ///
+  /// When a change is a pure deletion (`@@ -X,Y +Z,0 @@`), the removed lines no
+  /// longer exist in the working tree, so [`WorkspaceAnalyzer::find_node_at_line`]
+  /// on the current file cannot recover the affected symbol. This parses a
+  /// snapshot of the file as it existed at the base revision and runs the same
+  /// top-level-symbol resolution against the old-side line numbers. It therefore
+  /// handles both shapes of deletion:
+  ///
+  /// - removing a member of a still-present declaration (an object property, a
+  ///   `switch` case) resolves to the enclosing symbol, and
+  /// - removing an entire top-level declaration resolves to that declaration
+  ///   itself.
+  ///
+  /// The returned names are then traced through the *current* import graph —
+  /// consumers still `import { Foo }` from the file even after `Foo` is deleted,
+  /// so their projects are correctly reported affected. Returns de-duplicated
+  /// names, preserving first-seen order; an empty vec if the snapshot fails to
+  /// parse or no line resolves to a symbol.
+  pub fn find_deleted_symbols(
+    &self,
+    file_path: &Path,
+    base_source: &str,
+    deleted_lines: &[usize],
+  ) -> Vec<String> {
+    if deleted_lines.is_empty() {
+      return Vec::new();
+    }
+
+    let file_data = match Self::parse_source(file_path, base_source.to_string()) {
+      Ok(data) => data,
+      Err(e) => {
+        debug!("Failed to parse base revision of {:?}: {}", file_path, e);
+        return Vec::new();
+      }
+    };
+
+    let mut symbols: Vec<String> = Vec::new();
+    for &line in deleted_lines {
+      match Self::find_top_level_symbols(&file_data, line, 0) {
+        Ok(names) => {
+          for name in names {
+            if !symbols.contains(&name) {
+              symbols.push(name);
+            }
+          }
+        }
+        Err(e) => debug!(
+          "Error resolving deleted symbol at base line {} in {:?}: {}",
+          line, file_path, e
+        ),
+      }
+    }
+    symbols
   }
 }
 
@@ -1235,6 +1333,53 @@ const [x, y] = [1, 2]"#;
     let result = analyzer.find_node_at_line(&file_path, 1, 0);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), vec!["a".to_string()]);
+  }
+
+  #[test]
+  fn test_find_deleted_symbols_whole_exported_declaration() {
+    // The base revision no longer needs to be in `analyzer.files`: deletion
+    // recovery parses the passed-in snapshot directly. Deleting the entire
+    // `Removed` const (base lines 1-3) must resolve to "Removed".
+    let base_source = r#"export const Removed = {
+  value: 1,
+};
+
+export const Kept = 2;
+"#;
+    let profiler = Arc::new(Profiler::new(false));
+    let analyzer =
+      WorkspaceAnalyzer::new(vec![], Path::new("."), profiler).expect("Failed to create analyzer");
+
+    let symbols = analyzer.find_deleted_symbols(Path::new("gone.ts"), base_source, &[1, 2, 3]);
+    assert_eq!(symbols, vec!["Removed".to_string()]);
+  }
+
+  #[test]
+  fn test_find_deleted_symbols_member_resolves_enclosing_symbol() {
+    // Deleting a member line (base line 3, `beta: 2,`) resolves to the enclosing
+    // top-level symbol `TABLE`, not the member itself — de-duplicated across the
+    // deleted lines.
+    let base_source = r#"export const TABLE = {
+  alpha: 1,
+  beta: 2,
+  gamma: 3,
+};
+"#;
+    let profiler = Arc::new(Profiler::new(false));
+    let analyzer =
+      WorkspaceAnalyzer::new(vec![], Path::new("."), profiler).expect("Failed to create analyzer");
+
+    let symbols = analyzer.find_deleted_symbols(Path::new("table.ts"), base_source, &[3]);
+    assert_eq!(symbols, vec!["TABLE".to_string()]);
+  }
+
+  #[test]
+  fn test_find_deleted_symbols_empty_lines_returns_empty() {
+    let profiler = Arc::new(Profiler::new(false));
+    let analyzer =
+      WorkspaceAnalyzer::new(vec![], Path::new("."), profiler).expect("Failed to create analyzer");
+    let symbols = analyzer.find_deleted_symbols(Path::new("x.ts"), "export const A = 1;\n", &[]);
+    assert!(symbols.is_empty());
   }
 
   #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -61,13 +61,20 @@ pub struct Project {
 }
 
 /// A file with changed lines
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ChangedFile {
   /// Path to the file (relative to workspace root)
   pub file_path: PathBuf,
-  /// Line numbers that changed (1-indexed).
-  /// Empty for binary files (entire file considered changed).
+  /// New-side line numbers that changed (1-indexed).
+  /// Empty for binary files (entire file considered changed) and for
+  /// deletion-only files (all lines were removed — see `deleted_lines`).
   pub changed_lines: Vec<usize>,
+  /// Old-side (base-revision) line numbers removed by pure-deletion hunks
+  /// (`@@ -X,Y +Z,0 @@`), 1-indexed. These lines no longer exist in the
+  /// working tree, so the symbol they belonged to can only be recovered by
+  /// re-parsing the base revision at these lines — which is how dependents of
+  /// deleted code are traced. Empty when the change added or modified lines.
+  pub deleted_lines: Vec<usize>,
 }
 
 /// A reference to a symbol in the code

--- a/src/types.rs
+++ b/src/types.rs
@@ -61,7 +61,7 @@ pub struct Project {
 }
 
 /// A file with changed lines
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ChangedFile {
   /// Path to the file (relative to workspace root)
   pub file_path: PathBuf,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3944,6 +3944,11 @@ fn test_deletion_of_member_affects_dependents_via_enclosing_symbol() {
     .affected_projects;
 
   assert!(
+    affected.contains(&"lib".to_string()),
+    "lib should be affected (its file changed). Got: {:?}",
+    affected
+  );
+  assert!(
     affected.contains(&"app".to_string()),
     "app should be affected: `beta` was removed from `widget`, which app imports. Got: {:?}",
     affected

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3788,3 +3788,164 @@ export function unusedFn() {
     affected
   );
 }
+
+/// Scaffold a two-package monorepo where `app` imports `widget` from `lib`, then
+/// return the temp dir (kept alive by the caller), its canonical root, and a
+/// ready `TrueAffectedConfig`. `lib_src` is the initial contents of
+/// `libs/lib/src/index.ts`.
+fn scaffold_lib_app_repo(lib_src: &str) -> (TempDir, PathBuf, TrueAffectedConfig) {
+  let tmp = TempDir::new().expect("Failed to create temp dir");
+  let root = tmp.path().canonicalize().expect("canonicalize temp dir");
+
+  let lib_dir = root.join("libs/lib/src");
+  let app_dir = root.join("apps/app/src");
+  fs::create_dir_all(&lib_dir).unwrap();
+  fs::create_dir_all(&app_dir).unwrap();
+
+  fs::write(lib_dir.join("index.ts"), lib_src).unwrap();
+  fs::write(
+    app_dir.join("main.ts"),
+    r#"import { widget } from '@scope/lib';
+
+export function run() {
+  return widget();
+}
+"#,
+  )
+  .unwrap();
+  fs::write(
+    root.join("tsconfig.base.json"),
+    r#"{
+  "compilerOptions": {
+    "paths": {
+      "@scope/lib": ["libs/lib/src/index.ts"]
+    }
+  }
+}"#,
+  )
+  .unwrap();
+
+  git_in(&root, &["init"]);
+  git_in(&root, &["config", "user.email", "test@test.com"]);
+  git_in(&root, &["config", "user.name", "Test"]);
+  git_in(&root, &["branch", "-M", "main"]);
+  git_in(&root, &["add", "."]);
+  git_in(&root, &["commit", "-m", "initial"]);
+
+  let config = TrueAffectedConfig {
+    cwd: root.to_path_buf(),
+    base: "main".to_string(),
+    head: None,
+    root_ts_config: None,
+    projects: vec![
+      Project {
+        name: "lib".to_string(),
+        root: PathBuf::from("libs/lib/src"),
+        source_root: PathBuf::from("libs/lib/src"),
+        ts_config: None,
+        implicit_dependencies: vec![],
+        targets: vec![],
+      },
+      Project {
+        name: "app".to_string(),
+        root: PathBuf::from("apps/app/src"),
+        source_root: PathBuf::from("apps/app/src"),
+        ts_config: None,
+        implicit_dependencies: vec![],
+        targets: vec![],
+      },
+    ],
+    include: vec![],
+    ignored_paths: vec![],
+    lockfile_strategy: LockfileStrategy::None,
+  };
+
+  (tmp, root, config)
+}
+
+/// Regression for #74: deleting an *entire* exported symbol (a pure `+Z,0`
+/// deletion hunk) must still mark its dependents affected. The removed lines no
+/// longer exist in the working tree, so recovery re-parses the base revision at
+/// the old-side line range to recover the deleted symbol, then traces the
+/// current import graph — where `app` still imports it — to `app`.
+///
+/// This is the case the earlier new-side "anchor" heuristic could not solve:
+/// with the whole declaration gone, the anchor line resolves to whatever symbol
+/// now occupies it (or nothing), so `app` was silently dropped.
+#[test]
+fn test_deletion_of_whole_exported_symbol_affects_dependents() {
+  let (_tmp, root, config) = scaffold_lib_app_repo(
+    r#"export const widget = () => 1;
+
+export const obsolete = () => 2;
+"#,
+  );
+
+  // Delete the entire `widget` symbol that `app` imports. `git diff --unified=0`
+  // emits `@@ -1 +0,0 @@` — a pure deletion with no new-side line.
+  git_in(&root, &["checkout", "-b", "feature"]);
+  fs::write(
+    root.join("libs/lib/src/index.ts"),
+    r#"export const obsolete = () => 2;
+"#,
+  )
+  .unwrap();
+  git_in(&root, &["add", "."]);
+  git_in(&root, &["commit", "-m", "delete widget"]);
+
+  let profiler = Arc::new(Profiler::new(false));
+  let affected = find_affected(config, profiler)
+    .expect("find_affected failed")
+    .affected_projects;
+
+  assert!(
+    affected.contains(&"lib".to_string()),
+    "lib should be affected (its file changed). Got: {:?}",
+    affected
+  );
+  assert!(
+    affected.contains(&"app".to_string()),
+    "app should be affected: it imports `widget`, which was deleted. Got: {:?}",
+    affected
+  );
+}
+
+/// Deleting a *member* of an exported symbol (a property removed from an object)
+/// is also a pure `+Z,0` deletion. Recovery resolves the enclosing symbol
+/// (`widget`) from the base revision so `app`, which imports `widget`, is
+/// affected.
+#[test]
+fn test_deletion_of_member_affects_dependents_via_enclosing_symbol() {
+  let (_tmp, root, config) = scaffold_lib_app_repo(
+    r#"export const widget = {
+  alpha: 1,
+  beta: 2,
+  gamma: 3,
+};
+"#,
+  );
+
+  git_in(&root, &["checkout", "-b", "feature"]);
+  fs::write(
+    root.join("libs/lib/src/index.ts"),
+    r#"export const widget = {
+  alpha: 1,
+  gamma: 3,
+};
+"#,
+  )
+  .unwrap();
+  git_in(&root, &["add", "."]);
+  git_in(&root, &["commit", "-m", "delete beta"]);
+
+  let profiler = Arc::new(Profiler::new(false));
+  let affected = find_affected(config, profiler)
+    .expect("find_affected failed")
+    .affected_projects;
+
+  assert!(
+    affected.contains(&"app".to_string()),
+    "app should be affected: `beta` was removed from `widget`, which app imports. Got: {:?}",
+    affected
+  );
+}


### PR DESCRIPTION
Closes #74. Supersedes #72.

> Continues @noam-aharon20's work in #72 (branch preserved on top of the original commit). Opened as a fresh PR because we lacked push access to that PR's branch.

## Summary

`domino affected` silently drops the dependents of a **deleted** symbol. With `--unified=0` (always used by `get_diff`), removing lines produces a `@@ -X,Y +Z,0 @@` hunk whose new-side count is `0`, so it contributed nothing to `changed_lines`. Downstream, no symbol was resolved, reference traversal was skipped, and every project depending on the deleted symbol was dropped — only the file's own package stayed marked.

## What changed since the first review

The first revision anchored a `+Z,0` deletion to its **new-side** line `Z` and looked that up in the current file. As raised in review, that heuristic is **incorrect**:

- After a deletion, line `Z` belongs to whatever symbol now *occupies* it in the new file — not the deleted one. Deleting an entire top-level symbol either mis-attributes the change to the next symbol or resolves nothing, so the deleted symbol's real dependents were still dropped.
- It also left a dead `has_hunks` branch (flagged by @EladBezalel and CodeRabbit).

This revision replaces the heuristic with the semantically correct approach — issue **direction (2)**: recover the deleted symbols from the **base revision**.

## How it works now

1. **`git.rs`** — `LINE_RE` now captures both sides of the hunk header. A pure-deletion hunk (`W == 0`) records its **old-side** lines `X..X+Y` in a new `ChangedFile.deleted_lines` field; all other hunks contribute new-side lines to `changed_lines` as before. The dead `has_hunks` branch is removed. New helper `get_file_at_revision` reads `git show <merge-base>:./path`.
2. **`analyzer.rs`** — the top-level-symbol resolution is split out of `find_node_at_line` into `find_top_level_symbols(&FileSemanticData, …)` so it can run against a one-off base-revision parse (`parse_source`) that never enters `self.files`. New `find_deleted_symbols(file, base_source, deleted_lines)` parses the base snapshot and resolves the enclosing top-level symbol at each removed line (de-duplicated).
3. **`core.rs`** — for each changed file with `deleted_lines`, fetch the base content at the merge-base and merge the recovered symbols into the reference-traversal set. They're traced through the **current** import graph — consumers still `import { Foo }` even after `Foo` is deleted — so their projects are correctly reported.

This handles both shapes uniformly:

| Deletion shape | Resolves to | Result |
|---|---|---|
| Member of a still-present declaration (object property, `switch` case, interface field) | enclosing symbol | dependents traced ✅ |
| **Entire exported declaration** | the deleted symbol itself | dependents traced ✅ (the case the anchor could not solve) |

## Validation

Two-package Rush fixture; `package-b` consumes `lookup`, `User`, and `OBSOLETE` from `package-a`:

| Change | Before this PR | After |
|---|---|---|
| Delete an entry from an exported object | `[package-a]` ❌ | `[package-a, package-b]` ✅ |
| Delete a field from an exported interface | `[package-a]` ❌ | `[package-a, package-b]` ✅ |
| **Delete an entire exported symbol** | `[package-a]` ❌ | `[package-a, package-b]` ✅ |
| Delete a symbol **no project consumes** | `[package-a]` | `[package-a]` ✅ (stays precise) |

`cargo test --lib` — 212 passed. `cargo clippy --all-targets --all-features` and `cargo fmt --check` clean. New integration tests: `test_deletion_of_whole_exported_symbol_affects_dependents`, `test_deletion_of_member_affects_dependents_via_enclosing_symbol`.

### Real-world validation

Reproduced against a real large Rush monorepo on the exact commit that slipped through CI. The change removed one field from an exported schema object in a shared client package — a pure deletion hunk:

```
@@ -193 +192,0 @@ export const entitySchema = z.object({
-  removedField: z.string(),
```

Diffing that commit against its parent (`--base <parent> --head <commit>`):

| | Affected projects | Notes |
|---|---|---|
| **Before** (1.4.0) | **8** | only the packages owning the directly-changed files |
| **After** (this PR) | **49** | + every project that consumes the schema |
| **Delta** | **+41, −0** | purely additive — no project the old version reported was dropped |

The 41 newly-detected projects are exactly the downstream services and apps that import the schema and would break when the field is removed — the set CI skipped. Debug log confirms the mechanism:

```
Recovered 1 deleted symbol(s) from base revision of ".../<pkg>.ts": ["entitySchema"]
Processing symbol 'entitySchema' ...
Found 2 local references for 'entitySchema'
```

## Out of scope / known limitations

- **Whole-file deletion** — a fully deleted file isn't in the analyzer, so it still falls back to package-level marking.
- **Local-reference-only consumption** — deleting a whole symbol that a project reaches *only* through a local reference from another symbol (whose binding the deletion breaks) isn't traced, because the current-file symbol table no longer links the now-dangling reference. Direct cross-file imports of a deleted symbol (the common case) are traced.

Both are follow-ups; neither regresses today's behavior.
