### PR TITLE
fix(tests): address CodeRabbit review of #82 and harden the test CI job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,8 +51,14 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          # No step here needs to authenticate to the remote; don't leave the
+          # job-scoped token in the local git config while running repo code.
+          persist-credentials: false
       - name: Install Rust toolchain
         run: rustup show
       - name: Cache cargo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,7 @@ domino affected --lockfile-strategy full
 domino affected --cwd /path/to/monorepo
 ```
 
-Two things the flag list does not show:
+Three things the flag list does not show:
 
 - `--base` defaults to `origin/main` only as a clap placeholder. When it is left at that
   default, `git::detect_default_branch` overrides it with the repository's actual default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,15 +157,46 @@ domino affected
 # Use different base branch
 domino affected --base origin/develop
 
+# Compare a specific head commit (defaults to the working tree)
+domino affected --head <sha>
+
 # JSON output
 domino affected --json
 
 # Debug logging
 domino affected --debug
 
+# CI mode: suppress all logs, output results only
+domino affected --ci
+
+# Explicit root tsconfig
+domino affected --ts-config tsconfig.base.json
+
+# Performance profiling (equivalent to DOMINO_PROFILE=1)
+domino affected --profile
+
+# Generate an HTML dependency graph report
+domino affected --report ./affected-report.html
+
+# Lockfile change detection strategy: none | direct | full (default: direct)
+domino affected --lockfile-strategy full
+
 # Set working directory
 domino affected --cwd /path/to/monorepo
 ```
+
+Two things the flag list does not show:
+
+- `--base` defaults to `origin/main` only as a clap placeholder. When it is left at that
+  default, `git::detect_default_branch` overrides it with the repository's actual default
+  branch — so the literal string is not what gets compared.
+- `include` and `ignored_paths` exist in `TrueAffectedConfig` and are exposed to Node as
+  `include` / `ignoredPaths` (see `index.d.ts`), but have **no CLI flags**: `cli.rs` hardcodes
+  `include: vec![]` and a fixed ignore list (`node_modules`, `dist`, `build`, `.git`).
+- `--ts-config` is parsed into `TrueAffectedConfig::root_ts_config` and then **never read** —
+  nothing in `core.rs` consumes it, so passing it silently changes nothing. Resolution always
+  uses `<cwd>/tsconfig.base.json` (`resolve_options.rs`). Same for the `rootTsConfig` /
+  `include` / `ignoredPaths` options on the Node API.
 
 ## Architecture
 
@@ -174,14 +205,22 @@ domino affected --cwd /path/to/monorepo
 The true-affected detection follows this pipeline (see `src/core.rs`):
 
 1. **Git Diff Analysis** → Parse git diffs to identify changed files and specific changed lines
-2. **Semantic Parsing** → Parse all TypeScript/JavaScript files using Oxc to build AST and semantic model
-3. **Symbol Resolution** → Identify which symbols (functions, classes, constants, etc.) were actually modified based on changed line ranges
-4. **Reference Finding** → Recursively find all cross-file references to those symbols using the import/export graph
-5. **Project Mapping** → Map affected files back to their owning projects in the workspace
+2. **Named Inputs** → Apply Nx `namedInputs` global-invalidation patterns (e.g. `sharedGlobals`): a matching workspace-root file invalidates every project regardless of the semantic result
+3. **Semantic Parsing** → Parse all TypeScript/JavaScript files using Oxc to build AST and semantic model
+4. **Symbol Resolution** → Identify which symbols (functions, classes, constants, etc.) were actually modified based on changed line ranges
+5. **Reference Finding** → Recursively find all cross-file references to those symbols using the import/export graph
+6. **Asset References** → Changed _non-source_ files (HTML templates, stylesheets, JSON, images) are matched back to the source files that reference them, which then re-enter reference finding
+7. **Lockfile Changes** → Diff the lockfile to find changed direct dependencies, expand them transitively, and mark the source files importing them
+8. **Implicit Dependencies** → Pull in projects declared as implicit dependents of an affected project
+9. **Project Mapping & Union** → Map affected files back to their owning projects, and union the semantic result with the global-invalidation result from step 2
+
+The inline `// Step N` comments in `core.rs` are **not** a reliable ordering guide — they
+reflect the order features were added, not execution order (`Step 6` appears twice,
+`Step 5c` runs after `Step 6b`, and there is no `Step 7`).
 
 ### Key Components
 
-- **`src/core.rs`**: Main algorithm orchestration - implements the 5-step pipeline above
+- **`src/core.rs`**: Main algorithm orchestration - implements the pipeline above
 - **`src/git.rs`**: Git integration - parses diffs to identify changed files and line ranges
 - **`src/semantic/analyzer.rs`**: Workspace-wide semantic analysis using Oxc
   - Parses all files and builds AST
@@ -191,12 +230,31 @@ The true-affected detection follows this pipeline (see `src/core.rs`):
   - Uses `oxc_resolver` for module resolution (same as Rolldown/Nova)
   - Maintains resolution cache for performance
   - Recursively follows import chains to find all affected files
+- **`src/semantic/resolve_options.rs`**: Shared `oxc_resolver` configuration used by **both**
+  resolution paths (import-index builder and reference finder) - deliberately centralised to
+  prevent the two from drifting. Also home of `is_workspace_specifier` (see pitfall below)
+- **`src/semantic/assets.rs`**: Finds source-file references to non-source assets, so a changed
+  template or stylesheet can be traced to the code that uses it
+- **`src/lockfile.rs`**: Lockfile diffing for npm/yarn/pnpm/bun - detects changed direct
+  dependencies, builds a reverse dependency graph for transitive impact, then maps results to the
+  source files importing them. Refuses lockfiles over 256 MB to avoid OOM on constrained CI runners
+- **`src/named_inputs.rs`**: Parses Nx `namedInputs` into compiled global-invalidation and negation
+  glob patterns. Each pattern retains the `namedInput` name it came from so reports can echo the
+  term the user actually wrote in `nx.json`
+- **`src/tsconfig.rs`**: tsconfig loading - follows `extends` chains (depth-capped) and strips
+  comments before parsing
+- **`src/utils.rs`**: Source-file predicate, plus the pre-built sourceRoot→project index that makes
+  project lookup O(unique_roots) rather than O(projects) per call, and per-project tsconfig
+  `exclude` patterns (so an excluded `*.spec.ts` does not mark its project affected)
 - **`src/workspace/`**: Project discovery for different monorepo tools
   - `nx.rs`: Nx workspace support (nx.json, project.json)
-  - `turbo.rs`: Turborepo support (turbo.json)
+  - `turbo.rs`: Turborepo detection only - a 17-line shim that checks for `turbo.json` then
+    delegates to `workspaces.rs`; `turbo.json` itself is never parsed
+  - `rush.rs`: Rush support (`rush.json` `projects` array)
   - `workspaces.rs`: Generic npm/yarn/pnpm/bun workspaces
 - **`src/cli.rs`**: CLI interface using clap
 - **`src/lib.rs`**: N-API bindings for Node.js integration
+- **`src/types.rs`**: Shared config and result types (`TrueAffectedConfig`, `Project`, `ChangedFile`, `LockfileStrategy`)
 - **`src/profiler.rs`**: Performance profiling utilities
 - **`src/report.rs`**: Detailed analysis reports showing why projects are affected
 
@@ -308,8 +366,27 @@ This allows:
 ## Workspace Types Supported
 
 1. **Nx**: Detects via `nx.json`, reads project configuration from `project.json` files
-2. **Turborepo**: Detects via `turbo.json`, reads workspace configuration from root `package.json`
-3. **Generic workspaces**: Falls back to npm/yarn/pnpm/bun workspace detection from `package.json`
+2. **Turborepo**: Detects via `turbo.json`, then delegates entirely to generic workspace
+   discovery — `turbo.json` contents are never read, so Turbo-specific config (pipelines,
+   `globalDependencies`) has no effect on detection
+3. **Rush**: Detects via `rush.json`, reads its `projects` array
+4. **Generic workspaces**: Falls back to npm/yarn/pnpm/bun workspace detection from `package.json`
+
+## Repo Mechanics
+
+- The toolchain is pinned to 1.95.0 in `rust-toolchain.toml`; `Cargo.toml` declares a lower
+  `rust-version` (1.89.0) as the supported MSRV. Use the pinned version for local containers.
+- **`Cargo.lock` is gitignored**, so CI resolves dependencies fresh on every run. Dependency
+  version drift can therefore appear in CI with no local change to reproduce it.
+- `.husky/pre-commit` already enforces `cargo fmt --all -- --check` and
+  `cargo clippy --all-targets --all-features -- -D warnings`, so steps 2 and 3 of the checklist
+  below are automatic. **Tests are not run by the hook.** The same hook runs `lint-staged`, which
+  applies `prettier --write` to staged `js/ts/tsx/yml/yaml/md/json` and `taplo format` to `.toml` —
+  so editing this file and committing it will also normalise its existing Markdown formatting.
+- Version bumps go through `yarn version` → `napi version` + `scripts/sync-cargo-version.js`,
+  which keeps `Cargo.toml` in sync with `package.json`.
+- Preview releases are published by `scripts/publish-preview.js`, covered by
+  `tests/publish-preview.test.js` (run in the CI `lint` job, not by `cargo test`).
 
 ## Pre-Commit Checklist
 
@@ -350,6 +427,12 @@ cargo test --no-default-features --test cli_test -- --test-threads=1
 
 # For JavaScript/Node.js bindings
 yarn test
+
+# Publish-preview script (run by the CI lint job, not by cargo test)
+# NOTE: this rewrites the tracked files under tests/fixtures/test-repo/ with
+# machine-local absolute paths — `git checkout -- tests/fixtures/test-repo/`
+# afterwards so they are not committed.
+node --test tests/publish-preview.test.js
 ```
 
 All tests must pass before committing.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -265,14 +265,29 @@ pub fn ensure_fixture_git_repo(fixture: &Path) {
   // succeeds) but `main` is missing — environmental failures (git not on
   // PATH, dubious-ownership, permissions) should surface loudly later via
   // run_git instead of silently destroying the fixture.
-  if fixture.join(".git").exists()
+  // A `.git` *file* is linked-worktree or submodule metadata pointing at a
+  // gitdir that need not exist here. The scaffolding below always creates a
+  // real repository, so anything else is a broken fixture, not something to
+  // reuse — and leaving it in place makes every test fail with a confusing
+  // "not a git repository".
+  if fixture.join(".git").is_file() {
+    fs::remove_dir_all(fixture).expect("Failed to remove broken fixture");
+  }
+
+  // `show-ref --verify refs/heads/main` rather than `rev-parse --verify main`:
+  // the latter also resolves a *tag* named `main`, which would let a fixture
+  // with no local `main` branch skip regeneration and then fail on checkout.
+  if fixture.join(".git").is_dir()
     && git_succeeds(fixture, &["rev-parse", "--git-dir"])
-    && !git_succeeds(fixture, &["rev-parse", "--verify", "main"])
+    && !git_succeeds(
+      fixture,
+      &["show-ref", "--verify", "--quiet", "refs/heads/main"],
+    )
   {
     fs::remove_dir_all(fixture).expect("Failed to remove broken fixture");
   }
 
-  if fixture.join(".git").exists() {
+  if fixture.join(".git").is_dir() {
     return;
   }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,7 @@
 #![allow(dead_code)]
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Base fixture layout: an Nx-style monorepo with three projects.
@@ -235,6 +235,49 @@ fn git_succeeds(fixture: &Path, args: &[&str]) -> bool {
     .unwrap_or(false)
 }
 
+/// What git makes of the fixture directory.
+enum FixtureRepo {
+  /// git resolves the directory to the fixture's *own* repository.
+  Own,
+  /// git ran, but the directory is not the fixture's own repository.
+  Foreign,
+  /// git could not be executed at all.
+  GitUnavailable,
+}
+
+/// Ask git which repository `fixture` belongs to.
+///
+/// The question has to be *identity* ("which repo is this?"), not liveness
+/// ("does git work here?"). Git's repository discovery walks **up** from the
+/// working directory until it finds a structurally valid gitdir, silently
+/// skipping an empty or half-written `.git` rather than reporting it. Since
+/// this fixture lives inside domino's own checkout, a corrupt `.git` makes the
+/// walk land on domino itself — `rev-parse` and `show-ref refs/heads/main`
+/// then both succeed against *that* repo, the fixture looks reusable, and
+/// every later `git checkout` / `git commit` in the tests runs against the
+/// real working tree.
+fn classify_fixture_repo(fixture: &Path) -> FixtureRepo {
+  let Ok(output) = Command::new("git")
+    .args(["rev-parse", "--absolute-git-dir"])
+    .current_dir(fixture)
+    .output()
+  else {
+    return FixtureRepo::GitUnavailable;
+  };
+
+  if !output.status.success() {
+    return FixtureRepo::Foreign;
+  }
+
+  // `--absolute-git-dir` is absolute but not necessarily canonical (macOS
+  // resolves `/var` to `/private/var`), so compare canonicalised forms.
+  let resolved = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+  match (resolved.canonicalize(), fixture.join(".git").canonicalize()) {
+    (Ok(resolved), Ok(expected)) if resolved == expected => FixtureRepo::Own,
+    _ => FixtureRepo::Foreign,
+  }
+}
+
 fn write_fixture_files(fixture: &Path) {
   for (rel_path, content) in FIXTURE_FILES {
     let path = fixture.join(rel_path);
@@ -260,35 +303,33 @@ pub fn fixture_file_content(rel_path: &str) -> &'static str {
 /// regenerates the fixture if a previous interrupted run left the repo in a
 /// broken state (e.g. HEAD on an unborn branch).
 pub fn ensure_fixture_git_repo(fixture: &Path) {
-  // Self-heal: an interrupted run can leave .git without a usable main branch.
-  // Only wipe when git demonstrably works on this repo (`rev-parse --git-dir`
-  // succeeds) but `main` is missing — environmental failures (git not on
-  // PATH, dubious-ownership, permissions) should surface loudly later via
-  // run_git instead of silently destroying the fixture.
-  // A `.git` *file* is linked-worktree or submodule metadata pointing at a
-  // gitdir that need not exist here. The scaffolding below always creates a
-  // real repository, so anything else is a broken fixture, not something to
-  // reuse — and leaving it in place makes every test fail with a confusing
-  // "not a git repository".
-  if fixture.join(".git").is_file() {
-    fs::remove_dir_all(fixture).expect("Failed to remove broken fixture");
-  }
-
-  // `show-ref --verify refs/heads/main` rather than `rev-parse --verify main`:
-  // the latter also resolves a *tag* named `main`, which would let a fixture
-  // with no local `main` branch skip regeneration and then fail on checkout.
-  if fixture.join(".git").is_dir()
-    && git_succeeds(fixture, &["rev-parse", "--git-dir"])
-    && !git_succeeds(
-      fixture,
-      &["show-ref", "--verify", "--quiet", "refs/heads/main"],
-    )
-  {
-    fs::remove_dir_all(fixture).expect("Failed to remove broken fixture");
-  }
-
-  if fixture.join(".git").is_dir() {
-    return;
+  // Self-heal: an interrupted run can leave `.git` behind in a state that is
+  // not reusable. `classify_fixture_repo` is what decides, because merely
+  // asking whether git works here answers the wrong question — see its docs
+  // for why a corrupt `.git` resolves to the *enclosing* domino repository
+  // instead of failing. A `.git` *file* is covered by the same comparison:
+  // linked-worktree or submodule metadata points at a gitdir elsewhere.
+  if fixture.join(".git").exists() {
+    match classify_fixture_repo(fixture) {
+      // Reuse only when the fixture is its own repo *and* carries a local
+      // `main` branch. `show-ref --verify refs/heads/main` rather than
+      // `rev-parse --verify main`: the latter also resolves a *tag* named
+      // `main`, which would let a fixture with no local branch skip
+      // regeneration and then fail on checkout.
+      FixtureRepo::Own
+        if git_succeeds(
+          fixture,
+          &["show-ref", "--verify", "--quiet", "refs/heads/main"],
+        ) =>
+      {
+        return;
+      }
+      // git could not run at all. Deleting the fixture would not help — the
+      // rebuild below fails the same way — so leave it in place and let
+      // `run_git` surface the real error.
+      FixtureRepo::GitUnavailable => {}
+      _ => fs::remove_dir_all(fixture).expect("Failed to remove broken fixture"),
+    }
   }
 
   write_fixture_files(fixture);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -44,18 +44,109 @@ fn git_command(args: &[&str]) -> String {
 /// cannot be that guard: it also reports untracked and unstaged files, which
 /// other tests routinely leave in the shared fixture, so it would report work
 /// to commit when the index is actually empty.
+///
+/// Only exit code 0 means "clean"; 1 means "staged". Anything else (128 for a
+/// broken repo, a signal, a failure to launch git) is an unknown state that
+/// must not be silently reported as clean, or the caller skips a commit it
+/// owed the shared fixture. Such states resolve to "attempt the commit" so the
+/// error surfaces through `git_command`, which panics with git's stderr —
+/// rather than by panicking here, which would abort the whole test binary when
+/// the `Drop` caller below runs during unwinding.
 fn has_staged_changes(dir: &Path) -> bool {
   Command::new("git")
     .args(["diff", "--cached", "--quiet"])
     .current_dir(dir)
     .status()
-    .map(|status| status.code() == Some(1))
-    .unwrap_or(false)
+    .map(|status| status.code() != Some(0))
+    .unwrap_or(true)
 }
 
 /// Ensure the fixture repo exists and is initialized with git
 fn ensure_git_repo() {
   common::ensure_fixture_git_repo(&fixture_path());
+}
+
+/// A structurally invalid `.git` *directory* must not be reused, even though
+/// every liveness check passes against it.
+///
+/// Git's repository discovery walks up past an invalid gitdir instead of
+/// failing, so inside an enclosing repository `rev-parse` and
+/// `show-ref refs/heads/main` both succeed — against the *outer* repo. A
+/// fixture in that state looks healthy, and the `git checkout` / `git commit`
+/// calls these tests make would then run against domino's real working tree.
+#[test]
+fn fixture_regenerates_when_git_dir_is_invalid_inside_enclosing_repo() {
+  let tmp = TempDir::new().expect("Failed to create temp dir");
+  let (outer, fixture) = enclosing_repo_with_fixture(tmp.path());
+
+  // A fixture whose `.git` exists but holds none of the structure git needs.
+  fs::create_dir_all(fixture.join(".git")).expect("Failed to create fixture dir");
+
+  // Precondition: this is precisely the state that fools a liveness check.
+  assert_eq!(
+    canonical(git_in(&fixture, &["rev-parse", "--show-toplevel"])),
+    canonical(outer),
+    "expected the invalid .git to resolve to the enclosing repo"
+  );
+  git_in(&fixture, &["show-ref", "--verify", "refs/heads/main"]);
+
+  common::ensure_fixture_git_repo(&fixture);
+  assert_fixture_owns_itself(outer, &fixture);
+}
+
+/// A `.git` *file* is linked-worktree or submodule metadata pointing at a
+/// gitdir that need not exist here — exactly the state a container mount of a
+/// git worktree produces. The scaffolding only ever creates a real repository,
+/// so this is a broken fixture rather than something to reuse.
+#[test]
+fn fixture_regenerates_when_git_is_a_file() {
+  let tmp = TempDir::new().expect("Failed to create temp dir");
+  let (outer, fixture) = enclosing_repo_with_fixture(tmp.path());
+
+  fs::create_dir_all(&fixture).expect("Failed to create fixture dir");
+  fs::write(
+    fixture.join(".git"),
+    "gitdir: /nonexistent/worktrees/monorepo\n",
+  )
+  .expect("Failed to write .git file");
+
+  common::ensure_fixture_git_repo(&fixture);
+  assert_fixture_owns_itself(outer, &fixture);
+}
+
+/// Build an enclosing repository with a `main` branch, mirroring how the real
+/// fixture sits inside domino's own checkout. Returns `(outer, fixture)`; the
+/// fixture directory itself is left for the caller to stage.
+fn enclosing_repo_with_fixture(outer: &Path) -> (&Path, PathBuf) {
+  git_in(outer, &["init"]);
+  git_in(outer, &["config", "user.email", "test@example.com"]);
+  git_in(outer, &["config", "user.name", "Test User"]);
+  git_in(outer, &["branch", "-M", "main"]);
+  fs::write(outer.join("outer.txt"), "outer").expect("Failed to write file");
+  git_in(outer, &["add", "."]);
+  git_in(outer, &["commit", "-m", "Outer commit"]);
+
+  let fixture = outer.join("tests").join("fixtures").join("monorepo");
+  (outer, fixture)
+}
+
+/// The fixture is its own repository with its own `main` and generated
+/// content, and the enclosing repository was never committed to.
+fn assert_fixture_owns_itself(outer: &Path, fixture: &Path) {
+  assert_eq!(
+    canonical(git_in(fixture, &["rev-parse", "--show-toplevel"])),
+    canonical(fixture),
+    "fixture should have been regenerated as its own repository"
+  );
+  git_in(fixture, &["show-ref", "--verify", "refs/heads/main"]);
+  assert!(fixture.join("proj1/index.ts").exists());
+  assert_eq!(git_in(outer, &["rev-list", "--count", "HEAD"]), "1");
+}
+
+/// Resolve symlinks so `/var` and `/private/var` compare equal on macOS.
+fn canonical(path: impl AsRef<Path>) -> PathBuf {
+  fs::canonicalize(path.as_ref())
+    .unwrap_or_else(|e| panic!("Failed to canonicalize {}: {e}", path.as_ref().display()))
 }
 
 /// Setup: Create a test branch and reset to main after test

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5,7 +5,7 @@ use domino::profiler::Profiler;
 use domino::report::generate_html_report;
 use domino::types::{LockfileStrategy, Project, TrueAffectedConfig};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -35,6 +35,22 @@ fn git_command(args: &[&str]) -> String {
   }
 
   String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// True when `dir`'s index holds staged changes.
+///
+/// `git commit` fails when nothing is staged, so callers that may run against
+/// an already-up-to-date fixture have to guard it. `git status --porcelain`
+/// cannot be that guard: it also reports untracked and unstaged files, which
+/// other tests routinely leave in the shared fixture, so it would report work
+/// to commit when the index is actually empty.
+fn has_staged_changes(dir: &Path) -> bool {
+  Command::new("git")
+    .args(["diff", "--cached", "--quiet"])
+    .current_dir(dir)
+    .status()
+    .map(|status| status.code() == Some(1))
+    .unwrap_or(false)
 }
 
 /// Ensure the fixture repo exists and is initialized with git
@@ -270,11 +286,7 @@ fn test_three_dot_diff_behavior() {
         common::fixture_file_content("proj2/index.ts"),
       );
       git(&["add", "proj2/index.ts"]);
-      let staged = Command::new("git")
-        .args(["status", "--porcelain"])
-        .current_dir(&fixture)
-        .output();
-      if staged.map(|o| !o.stdout.is_empty()).unwrap_or(false) {
+      if has_staged_changes(&fixture) {
         git(&["commit", "-m", "Restore proj2/index.ts"]);
       }
     }
@@ -334,12 +346,7 @@ export function anotherFn() {
   git_command(&["add", "proj2/index.ts"]);
   // This commit lands on the fixture's main and persists across runs; on a
   // repeat run the content is already there, so only commit when staged
-  let staged = Command::new("git")
-    .args(["status", "--porcelain"])
-    .current_dir(fixture_path())
-    .output()
-    .expect("Failed to check git status");
-  if !staged.stdout.is_empty() {
+  if has_staged_changes(&fixture_path()) {
     git_command(&["commit", "-m", "Main branch change"]);
   }
 


### PR DESCRIPTION
Follow-up to #82, which was merged before its review comments were handled. All four comments were verified against the code rather than applied blindly; all four turned out to be valid.

## 1. Fixture self-heal accepted two broken states (Major)

`tests/common/mod.rs` decided whether to reuse or regenerate the fixture with `.git` existence plus `rev-parse --verify main`. Two states slipped through, and in both the code took the "looks healthy, reuse it" path — leaving every fixture test to fail with a confusing `fatal: not a git repository`:

- **`.git` as a file.** That's linked-worktree/submodule metadata pointing at a gitdir that need not exist here (exactly the state a container mount produces). The scaffolding always creates a real repository, so anything else is broken rather than reusable.
- **`main` as a tag.** `rev-parse --verify main` happily resolves a tag, so a repo with no local `main` branch passed the check and then failed on checkout. Now uses `show-ref --verify --quiet refs/heads/main`.

Both were reproduced empirically:

| case | pre-fix | post-fix |
|---|---|---|
| `.git` is a file | FAILED | regenerates, passes |
| `main` is a tag, no branch | FAILED | regenerates, passes |

## 2. Commit guards inspected the worktree, not the index (Minor)

The two guards added in #82 used `git status --porcelain`, which also reports untracked and unstaged files. Other tests routinely leave those in the shared fixture, so the guard could report work to commit while the index was empty — and `git commit` then fails the test. Both sites now share a `has_staged_changes` helper built on `git diff --cached --quiet` (exit 1 = staged changes), which looks only at the index.

## 3. Test job CI hardening (Minor)

The test job runs repository code on `pull_request`, so it now sets `persist-credentials: false` (no step in the job authenticates to the remote) and pins `permissions: contents: read` rather than inheriting the default set.

Not addressed: zizmor's `cache-poisoning` warning on the same job. Restricting it would mean dropping the cargo cache, which is what keeps the job fast, and the job's permissions are now read-only — happy to revisit if you'd rather.

## 4. Checklist missed a CI test gate (Minor)

Added `node --test tests/publish-preview.test.js` to the pre-commit checklist, since CI runs it in the lint job and the checklist only listed Rust tests.

Running it surfaced a **pre-existing issue worth a separate fix**: the test rewrites the *tracked* files under `tests/fixtures/test-repo/` with machine-local absolute paths, so it leaves a dirty tree and risks someone committing their own `/Users/...` path. I documented the `git checkout` cleanup next to the command rather than changing the JS test here; the real fix is to stop tracking those generated artifacts.

## Also included

Pipeline/CLI/repo-mechanics documentation that was sitting uncommitted in the working tree (not authored in this change). Its factual claims were checked against the source before committing — flag list vs `cli.rs`, the 256 MB lockfile cap, rush's `projects` array, the husky hook contents, toolchain 1.95.0 vs MSRV 1.89.0 — and all hold. One inaccuracy is corrected: it listed `--ts-config` among working flags, but `root_ts_config` is never read in `core.rs`, so the flag silently does nothing. That's now stated explicitly alongside the same caveat for the Node API's `rootTsConfig`/`include`/`ignoredPaths`.

## Testing

- lib 214, integration 63, cli 15 passing; `cargo clippy --all-targets --all-features` and `cargo fmt --check` clean
- the two self-heal cases verified to fail before the fix and pass after
- `node --test tests/publish-preview.test.js` passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Strengthened CI security by limiting repository permissions and preventing credentials from being persisted locally.

* **Documentation**
  * Expanded CLI and architecture documentation, including supported options, workspace behavior, detection stages, repository mechanics, and preview publishing checks.

* **Tests**
  * Improved fixture recovery and branch detection for more reliable integration tests.
  * Made staged-change checks and cleanup commits more accurate and conditional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->