### PR TITLE
fix(tests): drop removed TrueAffectedConfig fields from integration test literals

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2511,7 +2511,6 @@ export function Panel() {
     cwd: root.to_path_buf(),
     base: "main".to_string(),
     head: None,
-    root_ts_config: None,
     projects: vec![
       Project {
         name: "proj-a".to_string(),
@@ -2538,8 +2537,6 @@ export function Panel() {
         targets: vec![],
       },
     ],
-    include: vec![],
-    ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
   };
 
@@ -4523,10 +4520,7 @@ fn turbo_config_for(root: &Path, projects: Vec<Project>, base: &str) -> TrueAffe
     cwd: root.to_path_buf(),
     base: base.to_string(),
     head: None,
-    root_ts_config: None,
     projects,
-    include: vec![],
-    ignored_paths: vec![],
     lockfile_strategy: LockfileStrategy::None,
   }
 }


### PR DESCRIPTION
## Problem

`main` is red — the integration test binary does not compile (6× `E0560: struct \`TrueAffectedConfig\` has no field named ...` at `tests/integration_test.rs`:2514/2541/2542/4526/4528/4529). [Failing run](https://github.com/frontops-dev/domino/actions/runs/30272703340/job/89999049501)

Cause: a **semantic conflict** that no PR could see. #83 removed `root_ts_config`/`include`/`ignored_paths` from `TrueAffectedConfig` and cleaned up every test literal that existed at the time. Meanwhile #84, #86, #89 and #90 each added *new* test literals that still set those fields. Each PR was individually green and textually conflict-free, so GitHub reported them all mergeable — but the union doesn't compile.

## Solution

Delete the six stale field initializers. No production code touched.

## Testing

- `cargo test --no-default-features --test integration_test -- --test-threads=1` → **74 passed, 0 failed** (previously: did not compile)
- `cargo test --no-default-features --lib` → 239 passed
- `cargo test --no-default-features --test cli_test -- --test-threads=1` → 16 passed
- `cargo clippy --all-targets --no-default-features` clean, `cargo fmt --check` clean

## Note for the remaining PRs

#85, #87 and #88 are still open and will hit the same thing when they merge `main`: any test literal they add must not carry the three removed fields. Their branch updates are in progress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test configuration setup to align with the current configuration format.
  * Adjusted asset batching and Turborepo test scenarios without changing end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->