### PR TITLE
ci: never cancel main runs, and make publish concurrency-safe

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,10 @@ env:
       - reopened
       - edited
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Pull request runs are superseded by newer pushes to the same branch, but each
+  # commit on main gets its own group so it is never cancelled or queued: pushes to
+  # main publish release artifacts and must always run the full matrix.
+  group: ${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
   cancel-in-progress: true
 jobs:
   lint:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -376,6 +376,12 @@ jobs:
     name: Publish
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    # Main-branch runs are no longer cancelled, so several can be in flight at once.
+    # Releases must still happen one at a time: queue publishes instead of overlapping
+    # them, since each derives its version from the latest tag.
+    concurrency:
+      group: publish-main
+      cancel-in-progress: false
     permissions:
       contents: write
       id-token: write
@@ -404,6 +410,10 @@ jobs:
       - name: Determine version bump
         id: version
         run: |
+          # Re-fetch tags: this checkout was made when the job was queued, so it can
+          # predate a tag an earlier main-branch run pushed while we were waiting.
+          git fetch --force --tags origin main
+
           COMMIT_MSG=$(git log -1 --pretty=%s)
 
           if echo "$COMMIT_MSG" | grep -qE "^[0-9]+\.[0-9]+\.[0-9]+$"; then
@@ -463,25 +473,53 @@ jobs:
             echo "::warning::If this is unintentional, check commit messages for accidental '!:' suffix or 'BREAKING CHANGE:' footer"
           fi
 
+          # Bump from the last tag rather than from package.json: a queued run's checkout
+          # can still carry the pre-bump version even though a release already happened.
+          BASE_VERSION="${LAST_TAG#v}"
+          if [ -z "$BASE_VERSION" ]; then
+            BASE_VERSION=$(node -p "require('./package.json').version")
+          fi
+          NEXT_VERSION=$(node -e 'const [b,t]=process.argv.slice(1);const [x,y,z]=b.split(".").map(Number);console.log(t==="major"?`${x+1}.0.0`:t==="minor"?`${x}.${y+1}.0`:`${x}.${y}.${z+1}`)' "$BASE_VERSION" "$BUMP")
+
+          echo "Next version: $BASE_VERSION -> $NEXT_VERSION"
+
           echo "bump=$BUMP" >> $GITHUB_OUTPUT
+          echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
       - name: Bump version
         id: bump
         if: steps.version.outputs.is_release != 'true'
         run: |
-          npm version ${{ steps.version.outputs.bump }} --no-git-tag-version --ignore-scripts
+          npm version ${{ steps.version.outputs.next_version }} --no-git-tag-version --ignore-scripts --allow-same-version
           node scripts/sync-cargo-version.js
           NEW_VERSION=$(node -p "require('./package.json').version")
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "Bumped to $NEW_VERSION"
-      - name: Generate packages
+      - name: Claim version
+        id: claim
         if: steps.version.outputs.is_release != 'true'
+        run: |
+          TAG="v${{ steps.bump.outputs.new_version }}"
+          # Compare-and-swap on the tag: creating a remote ref is atomic and reversible,
+          # so whoever wins owns the version and everyone else stops here — before npm
+          # publish, the only irreversible step. Re-running the same commit re-pushes the
+          # same ref, which is a no-op success, so a retry after a flaky publish works.
+          # The tag marks the commit that was released; the version commit follows it.
+          if git push origin "HEAD:refs/tags/${TAG}"; then
+            echo "Claimed ${TAG}"
+            echo "claimed=true" >> $GITHUB_OUTPUT
+          else
+            echo "::notice::${TAG} is already claimed by another run — skipping release"
+            echo "claimed=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Generate packages
+        if: steps.claim.outputs.claimed == 'true'
         run: node scripts/generate-packages.js
       - name: List packages
-        if: steps.version.outputs.is_release != 'true'
+        if: steps.claim.outputs.claimed == 'true'
         run: ls -R ./npm
         shell: bash
       - name: Publish to npm
-        if: steps.version.outputs.is_release != 'true'
+        if: steps.claim.outputs.claimed == 'true'
         run: |
           PKG_NAME=$(node -p "require('./package.json').name")
           PKG_VERSION=$(node -p "require('./package.json').version")
@@ -493,8 +531,8 @@ jobs:
           npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Push version commit and tag
-        if: steps.version.outputs.is_release != 'true'
+      - name: Push version commit
+        if: steps.claim.outputs.claimed == 'true'
         env:
           HUSKY: '0'
         run: |
@@ -513,5 +551,17 @@ jobs:
           done
           git add package.json Cargo.toml yarn.lock
           git commit -m "${{ steps.bump.outputs.new_version }}"
-          git tag "v${{ steps.bump.outputs.new_version }}"
-          git push --atomic origin main "v${{ steps.bump.outputs.new_version }}"
+          # The tag was already pushed to claim the version, so only the commit is left.
+          # A feature commit can land on main while we publish, so rebase and retry.
+          for i in 1 2 3; do
+            if git push origin HEAD:refs/heads/main; then
+              exit 0
+            fi
+            echo "push attempt $i was rejected — rebasing onto origin/main"
+            git fetch origin main
+            git rebase origin/main || {
+              echo "::error::v${{ steps.bump.outputs.new_version }} is published and tagged, but the version commit conflicts with main and must be pushed manually"
+              exit 1
+            }
+          done
+          exit 1


### PR DESCRIPTION
## Problem

Two related problems, one caused by fixing the other.

**1. Runs on `main` were cancelled.** The workflow used a single concurrency group per
ref with cancellation enabled, so every push to `main` produced the same group key
(`CI-refs/heads/main`) and commit N+1 cancelled the still-running job for commit N.
Back-to-back merges left `main` with no full verification, and could abort the
`publish` job partway through a release.

**2. Removing that cancellation exposes a publish race.** `cancel-in-progress` was
quietly doing double duty: as a CI cost saver *and* as a de-facto debounce on the
release pipeline. Only the newest commit ever reached `npm publish`, so the
auto-versioning logic never had to be concurrency-safe. Without cancellation, two
merges landing together would both publish:

| | Run A | Run B |
|---|---|---|
| version source | own `package.json` (2.0.1) | own `package.json` (2.0.1) |
| computed version | 2.0.2 | 2.0.2 |
| `npm view` guard | not published yet → proceed | not published yet → proceed |
| outcome | publishes 2.0.2, pushes tag | **fails** — 403 over-publish or rejected push |

The `npm view` check is a TOCTOU test, not a lock. Worse than the red job: 2.0.2 is
built from A's tree, and B's own changes may never get published at all.

## Solution

### Verification: per-commit groups (commit 1)

Append the commit sha to the concurrency group **only** for `refs/heads/main`:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
```

| Event | Group |
|---|---|
| push `main` @ abc123 | `CI-refs/heads/main-abc123` |
| push `main` @ def456 | `CI-refs/heads/main-def456` |
| PR #42 | `CI-refs/pull/42/merge` |

Each `main` commit is alone in its group, so it is never cancelled *and* never queued
behind another — the full matrix runs for every commit. PR runs keep the existing
per-ref group, so pushing to a PR branch still cancels the superseded run.

Note that `cancel-in-progress: false` on a *shared* group would not work here: it
queues the newer run rather than running it, so pushes to `main` would serialize
behind the whole build matrix.

### Release: compare-and-swap (commit 2)

All inside the `publish` job:

1. **Queue, don't overlap** — job-level `concurrency: { group: publish-main,
   cancel-in-progress: false }`.
2. **Version from the last tag, not `package.json`** — re-fetch tags first, since a
   queued run's checkout predates the tag an earlier run pushed while it waited.
3. **Claim the version before publishing** — push the tag on its own. Creating a
   remote ref is atomic and reversible, so the run that wins owns the version;
   losers `exit 0` *before* `npm publish`, the only irreversible step.
4. **Publish, then push the version commit**, rebasing onto `main` if a feature
   commit landed meanwhile.

The `npm view` guard is retained, so a retry after a flaky publish stays idempotent:
re-pushing the same tag from the same commit is a no-op success, which lets a re-run
proceed rather than skip.

### Deviation from review feedback

The review asked for `git push --atomic origin main v<ver>` (commit **and** tag)
before publishing. That is not implementable here — the release has an ordering cycle:

> `npm publish` → platform packages exist on the registry → `yarn install` can resolve
> them → `yarn.lock` is valid → the version commit passes `--frozen-lockfile` in its
> own CI run

`scripts/generate-packages.js` repoints root `optionalDependencies` at
`@front-ops/domino-<platform>@<new version>`, and `prepublishOnly`
(`napi prepublish`) is what publishes those platform packages. So a version commit
pushed *before* `npm publish` carries a `yarn.lock` that cannot resolve, and the
bot's own CI run on that commit goes red. (This is what the existing retry loop
commented *"handle npm registry propagation delay after publish"* is about.)

The atomic push is therefore split: the **tag** is the CAS and goes first, the commit
follows the publish. This keeps the property the feedback is actually after — a
reversible claim ahead of any irreversible side effect.

**Consequence to be aware of:** the release tag now points at the commit that was
released, rather than at the version-bump commit that follows it. `git describe` and
bump derivation are unaffected (the tag is still an ancestor). A stale tag from a run
that died before publishing is self-healing: the next run simply bumps past it.

## Key Changes

- `.github/workflows/CI.yml`
  - sha-suffixed workflow concurrency group for `main`
  - `publish`: job concurrency group, tag re-fetch, version derived from last tag,
    new `Claim version` CAS step, side-effecting steps gated on the claim, and a
    rebase-retry on the version commit push

## Testing

- Workflow YAML parses; all 8 jobs resolve; prettier clean.
- Version derivation snippet extracted from the workflow and executed:
  `v2.0.1`+patch→`2.0.2`, +minor→`2.1.0`, +major→`3.0.0`, tagless→`package.json`+1.
- CAS verified against local repos: second claim of the same version from a different
  sha is `rejected (already exists)` → `exit 0` with no npm side effect; re-claim from
  the same sha is `Everything up-to-date` → the idempotent retry path.
- Rebase-retry verified on realistic history (version commit replays cleanly over a
  feature commit that landed during the publish; both changes survive).
- Step gating verified: with `is_release=true` the claim step is skipped, so `claimed`
  is empty and every side-effecting step skips.
- No Rust or JS sources touched, so the `cargo`/`yarn` suites are unaffected.
- Not exercised end-to-end against the real npm registry — the first real release
  after merge is the remaining verification.

## Out of Scope

- `pages.yml` — docs deploy where only the newest build matters, cancellation is correct.
- `preview-release.yml` — gated to `workflow_run.event == 'pull_request'`, never runs
  for `main` pushes.
- Merge queue — a reasonable follow-up for bulk-merge correctness, not needed for this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow reliability when multiple builds run concurrently.
  * Prevented active main-branch releases from being canceled unexpectedly.
  * Reduced versioning conflicts and ensured packages are published only after a release is successfully claimed.
  * Added safer handling for synchronizing release changes with the latest main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->