### PR TITLE
docs: state MIT license directly and fix traf repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Overview
 
-domino is a drop-in replacement for the TypeScript version of [traf](https://github.com/@lemonade-hq/traf), providing the same semantic analysis capabilities with significantly better performance thanks to Rust and the Oxc parser.
+domino is a drop-in replacement for the TypeScript version of [traf](https://github.com/lemonade-hq/traf), providing the same semantic analysis capabilities with significantly better performance thanks to Rust and the Oxc parser.
 
 ## Features
 
@@ -232,11 +232,11 @@ RUST_LOG=domino=debug cargo run -- affected
 
 ## License
 
-Same as the original traf project.
+MIT - see [LICENSE](LICENSE).
 
 ## Credits
 
-This is a Rust port of the original [traf](https://github.com/@lemonade-hq/traf) TypeScript implementation.
+This is a Rust port of the original [traf](https://github.com/lemonade-hq/traf) TypeScript implementation.
 
 Built with:
 


### PR DESCRIPTION
## Problem

Two issues in the README:

1. **License section** deferred to another project — "Same as the original traf project." — instead of naming a license. That is unverifiable from this repo alone, and it disagreed with the three places that *do* declare it: the `LICENSE` file (MIT, © frontops.dev), `"license": "MIT"` in `package.json`, and `license = "MIT"` in `Cargo.toml`.

2. **Broken traf links.** Both references used the npm scope form `https://github.com/@lemonade-hq/traf`. GitHub org paths carry no `@`, so the links 404. This appeared twice — Overview (line 14) and Credits (line 239).

## Solution

- License section now reads `MIT - see [LICENSE](LICENSE).`, pointing at the file already in the repo.
- Both traf links corrected to `https://github.com/lemonade-hq/traf`.

## Key changes

| Location | Before | After |
|---|---|---|
| `README.md` Overview | `github.com/@lemonade-hq/traf` | `github.com/lemonade-hq/traf` |
| `README.md` License | `Same as the original traf project.` | `MIT - see [LICENSE](LICENSE).` |
| `README.md` Credits | `github.com/@lemonade-hq/traf` | `github.com/lemonade-hq/traf` |

## Testing

- Verified the corrected URL resolves: `curl -o /dev/null -w '%{http_code}' https://github.com/lemonade-hq/traf` → `200`.
- Confirmed the stated license matches `LICENSE`, `package.json`, and `Cargo.toml`.
- Pre-commit hooks (`cargo fmt --check`, `cargo clippy -D warnings`, `prettier` via lint-staged) passed; prettier introduced no incidental reformatting.

Docs-only change — no code paths touched, so no test adjustments were needed.

## Breaking changes

None.